### PR TITLE
Flip the loop, add some logging

### DIFF
--- a/plugin/src/events.ts
+++ b/plugin/src/events.ts
@@ -1,10 +1,15 @@
 import { makeShopifyFetch } from "./rest";
 
+interface Event {
+  subject_id: number;
+  subject_type: string;
+}
+
 export function eventsApi(options: ShopifyPluginOptions) {
   const shopifyFetch = makeShopifyFetch(options);
 
   return {
-    async fetchDestroyEventsSince(date: Date) {
+    async fetchDestroyEventsSince(date: Date): Promise<Event[]> {
       let resp = await shopifyFetch(
         `/events.json?limit=250&verb=destroy&created_at_min=${date.toISOString()}`
       );

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -241,12 +241,24 @@ async function sourceChangedNodes(
   if (destroyEvents.length) {
     gatsbyApi.reporter.info(`Removing matching nodes from Gatsby`);
     destroyEvents.forEach((e) => {
-      const node = gatsbyApi
-        .getNodesByType(`Shopify${e.subject_type}`)
-        .find((n) => e.subject_id === parseInt(n.shopifyId as string, 10));
+      /**
+       * When we remove gatsby-node-helpers we'll be able to skip this part,
+       * but for now we'll have to use the same createNodeId function that
+       * this library provides.
+       */
+      const nodeHelpers = createNodeHelpers({
+        typePrefix: `Shopify`,
+        createNodeId: gatsbyApi.createNodeId,
+        createContentDigest: gatsbyApi.createContentDigest,
+      });
+
+      const nodeId = nodeHelpers.createNodeId(e.subject_id.toString());
+      const node = gatsbyApi.getNode(nodeId);
 
       if (node) {
-        gatsbyApi.reporter.info(`Removing ${node.internal.type}: ${node.id}`);
+        gatsbyApi.reporter.info(
+          `Removing ${node.internal.type}: ${node.id} with shopifyId ${e.subject_id}`
+        );
         gatsbyApi.actions.deleteNode(node);
       }
     });


### PR DESCRIPTION
Probably more efficient to loop over the events and find a matching node, instead of looping over nodes and finding the matching event.

Also adding some logging to verify whether we're deleting stuff.