### PR TITLE
Use fully qualified shopify ID to generate node ID for lookup

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-shopify-experimental",
-  "version": "1.11.12",
+  "version": "1.11.13",
   "description": "",
   "scripts": {
     "watch": "tsc-watch",
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/gatsby-inc/gatsby-source-shopify-graphql-poc#readme",
   "dependencies": {
-    "gatsby-node-helpers": "^1.0.3",
+    "gatsby-node-helpers": "^1.2.1",
     "gatsby-source-filesystem": "^2.10.0",
     "node-fetch": "^2.6.1",
     "typescript": "^4.1.3"

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-shopify-experimental",
-  "version": "1.11.11",
+  "version": "1.11.12",
   "description": "",
   "scripts": {
     "watch": "tsc-watch",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-shopify-experimental",
-  "version": "1.11.7",
+  "version": "1.11.11",
   "description": "",
   "scripts": {
     "watch": "tsc-watch",

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -252,7 +252,8 @@ async function sourceChangedNodes(
         createContentDigest: gatsbyApi.createContentDigest,
       });
 
-      const nodeId = nodeHelpers.createNodeId(e.subject_id.toString());
+      const id = `gid://shopify/${e.subject_type}/${e.subject_id}`;
+      const nodeId = nodeHelpers.createNodeId(id);
       const node = gatsbyApi.getNode(nodeId);
 
       if (node) {

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -253,6 +253,7 @@ async function sourceChangedNodes(
       });
 
       const id = `gid://shopify/${e.subject_type}/${e.subject_id}`;
+      gatsbyApi.reporter.info(`Looking up node with ID: ${id}`);
       const nodeId = nodeHelpers.createNodeId(id);
       const node = gatsbyApi.getNode(nodeId);
 
@@ -261,6 +262,8 @@ async function sourceChangedNodes(
           `Removing ${node.internal.type}: ${node.id} with shopifyId ${e.subject_id}`
         );
         gatsbyApi.actions.deleteNode(node);
+      } else {
+        gatsbyApi.reporter.info(`Couldn't find node with ID: ${id}`);
       }
     });
   }

--- a/plugin/src/node-builder.ts
+++ b/plugin/src/node-builder.ts
@@ -119,7 +119,9 @@ export function nodeBuilder(
   } = {};
   const getFactory = (remoteType: string) => {
     if (!factoryMap[remoteType]) {
-      factoryMap[remoteType] = nodeHelpers.createNodeFactory(remoteType);
+      factoryMap[remoteType] = nodeHelpers.createNodeFactory(remoteType, {
+        idIsGloballyUnique: true,
+      });
     }
     return factoryMap[remoteType];
   };

--- a/plugin/yarn.lock
+++ b/plugin/yarn.lock
@@ -462,10 +462,10 @@ gatsby-core-utils@^2.0.0-next.0:
     tmp "^0.2.1"
     xdg-basedir "^4.0.0"
 
-gatsby-node-helpers@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/gatsby-node-helpers/-/gatsby-node-helpers-1.0.3.tgz#bf87fc301de90ed9806bbea74325acb7606887b9"
-  integrity sha512-qIBK7V77A0gpHz20H8T4dWn2gc0CJPqM3mUYeOFRTPcUgBbVKczehyrrtSlmgq+NOcqKrA+vbEkNjzx11+Equg==
+gatsby-node-helpers@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/gatsby-node-helpers/-/gatsby-node-helpers-1.2.1.tgz#9d21adcaa2e02baa67d4bdf16a3bb27a3a84d553"
+  integrity sha512-fYNQhp7/3sBUkb9QR31CZm6XChN2A78npow/PNglx5U1Sv8Zmd07Io8Mc2K7UO2hUCCSuAmgkSqlqq71NupdQA==
   dependencies:
     camel-case "^4.1.2"
     pascal-case "^3.1.2"


### PR DESCRIPTION
When we create nodes, we generate the ID using the fully qualified shopify ID that comes back from the bulk API. But when we use the events API, we only get back the numeric portion of that ID, so we need to format that in order to generate an ID that we can use to look up the node.