### PR TITLE
Account for line items with no product

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-shopify-experimental",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "",
   "scripts": {
     "watch": "tsc-watch",

--- a/plugin/src/node-builder.ts
+++ b/plugin/src/node-builder.ts
@@ -78,8 +78,10 @@ async function processChildImage(
 const processorMap: ProcessorMap = {
   LineItem: async (node) => {
     const lineItem = node;
-    lineItem.productId = (lineItem.product as { id: string }).id;
-    delete lineItem.product;
+    if (lineItem.product) {
+      lineItem.productId = (lineItem.product as BulkResult).id;
+      delete lineItem.product;
+    }
   },
   ProductImage: async (node, gatsbyApi, options) => {
     if (options.downloadImages) {


### PR DESCRIPTION
A line item's product is optional and is indeed sometimes absent from e.g. our orders in the swag store. This PR makes sure we don't blow up when a line item has no product.

Fixes #51 