### PR TITLE
Report the error code for unknown operation failures

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-shopify-experimental",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "",
   "scripts": {
     "watch": "tsc-watch",

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -131,6 +131,14 @@ function makeSourceFromOperation(
             error: e,
           });
         }
+
+        reporter.panic({
+          id: errorCodes.unknownSourcingFailure,
+          context: {
+            sourceMessage: `Could not source from bulk operation: ${e.node.errorCode}`,
+          },
+          error: e,
+        });
       }
 
       reporter.panic({


### PR DESCRIPTION
#58 was failing due to an incorrect API key, but this would have probably been easier to discover if we'd included the error code in the panic message.