### PR TITLE
Better representation of user errors and statuses

### DIFF
--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -60,13 +60,13 @@ function makeSourceFromOperation(
 
       if (userErrors.length) {
         reporter.panic(
-          {
+          userErrors.map((e) => ({
             id: errorCodes.bulkOperationFailed,
             context: {
-              sourceMessage: `Couldn't perform bulk operation`,
+              sourceMessage: `Couldn't initiate bulk operation query`,
             },
-          },
-          userErrors
+            error: new Error(`${e.field.join(".")}: ${e.message}`),
+          }))
         );
       }
 

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -36,9 +36,7 @@ export function pluginOptionsSchema({ Joi }: PluginOptionsSchemaArgs) {
 
 function makeSourceFromOperation(
   finishLastOperation: () => Promise<void>,
-  completedOperation: (
-    id: string
-  ) => Promise<{ node: { objectCount: string; url: string } }>,
+  completedOperation: (id: string) => Promise<{ node: BulkOperationNode }>,
   gatsbyApi: SourceNodesArgs,
   options: ShopifyPluginOptions
 ) {
@@ -78,7 +76,7 @@ function makeSourceFromOperation(
       let resp = await completedOperation(bulkOperation.id);
       reporter.info(`Completed bulk operation ${op.name}: ${bulkOperation.id}`);
 
-      if (parseInt(resp.node.objectCount, 10) === 0) {
+      if (resp.node.objectCount === 0) {
         reporter.info(`No data was returned for this operation`);
         operationTimer.end();
         return;

--- a/plugin/src/operations.ts
+++ b/plugin/src/operations.ts
@@ -17,7 +17,7 @@ import {
 
 export interface BulkOperationRunQueryResponse {
   bulkOperationRunQuery: {
-    userErrors: Error[];
+    userErrors: { field: string[]; message: string }[];
     bulkOperation: {
       id: string;
     };
@@ -33,10 +33,19 @@ export interface ShopifyBulkOperation {
   ) => Promise<NodeInput>[];
 }
 
+type BulkOperationStatus =
+  | "CANCELED"
+  | "CANCELING"
+  | "COMPLETED"
+  | "CREATED"
+  | "EXPIRED"
+  | "FAILED"
+  | "RUNNING";
+
 interface CurrentBulkOperationResponse {
   currentBulkOperation: {
     id: string;
-    status: string;
+    status: BulkOperationStatus;
   };
 }
 

--- a/plugin/src/operations.ts
+++ b/plugin/src/operations.ts
@@ -15,13 +15,21 @@ import {
   incrementalCollectionsQuery,
 } from "./queries";
 
+interface UserError {
+  field: string[];
+  message: string;
+}
+
 export interface BulkOperationRunQueryResponse {
   bulkOperationRunQuery: {
-    userErrors: { field: string[]; message: string }[];
-    bulkOperation: {
-      id: string;
-    };
+    userErrors: UserError[];
+    bulkOperation: BulkOperationNode;
   };
+}
+
+export interface BulkOperationCancelResponse {
+  bulkOperation: BulkOperationNode;
+  userErrors: UserError[];
 }
 
 export interface ShopifyBulkOperation {
@@ -183,7 +191,9 @@ export function createOperations(
     ),
 
     cancelOperation(id: string) {
-      return client.request(CANCEL_OPERATION, { id });
+      return client.request<BulkOperationCancelResponse>(CANCEL_OPERATION, {
+        id,
+      });
     },
 
     finishLastOperation,

--- a/plugin/types/interface.d.ts
+++ b/plugin/types/interface.d.ts
@@ -16,8 +16,8 @@ type BulkResults = BulkResult[];
 
 interface BulkOperationNode {
   status: string;
-  objectCount: string;
+  objectCount: number;
   url: string;
   id: string;
-  errorCode: string;
+  errorCode: "ACCESS_DENIED" | "INTERNAL_SERVER_ERROR" | "TIMEOUT";
 }


### PR DESCRIPTION
The docs are perhaps not organized intuitively but are certainly more complete than I thought previously.

https://shopify.dev/docs/admin-api/graphql/reference/bulk-operations/bulkoperationstatus
https://shopify.dev/docs/admin-api/graphql/reference/usererror