### PR TITLE
Get the query when polling the operation

### DIFF
--- a/plugin/src/queries.ts
+++ b/plugin/src/queries.ts
@@ -10,6 +10,7 @@ export const OPERATION_STATUS_QUERY = `
         fileSize
         url
         partialDataUrl
+        query
       }
     }
   `;
@@ -27,6 +28,7 @@ query OPERATION_BY_ID($id: ID!) {
       fileSize
       url
       partialDataUrl
+      query
     }
   }
 }

--- a/plugin/types/interface.d.ts
+++ b/plugin/types/interface.d.ts
@@ -20,4 +20,5 @@ interface BulkOperationNode {
   url: string;
   id: string;
   errorCode: "ACCESS_DENIED" | "INTERNAL_SERVER_ERROR" | "TIMEOUT";
+  query: string;
 }


### PR DESCRIPTION
When requesting info about a bulk operation, you can ask for the `query` field which will give you the query that you submitted to initiate the bulk operation. Having this will probably be helpful later so we can save result URLs and know which queries the results correspond to.