### PR TITLE
Replace custom resolvers with @link directives

### DIFF
--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -312,6 +312,10 @@ export function createSchemaCustomization({
       collections: [ShopifyCollection] @link(from: "id", by: "productIds")
     }
 
+    type ShopifyCollection implements Node {
+      products: [ShopifyProduct] @link(from: "productIds", by: "id")
+    }
+
     type ShopifyProductFeaturedImage {
       localFile: File @link
     }
@@ -342,51 +346,27 @@ export function createSchemaCustomization({
   `);
 }
 
-/**
- * FIXME
- *
- * What are the types for the resolve functions?
- */
 export function createResolvers(
   { createResolvers }: CreateResolversArgs,
-  { downloadImages, shopifyConnections = [] }: ShopifyPluginOptions
+  { downloadImages }: ShopifyPluginOptions
 ) {
-  const resolvers: Record<string, any> = {};
-
   if (!downloadImages) {
-    resolvers.ShopifyProductImage = {
-      gatsbyImageData: getGatsbyImageResolver(resolveGatsbyImageData),
-    };
+    const resolvers = {
+      ShopifyProductImage: {
+        gatsbyImageData: getGatsbyImageResolver(resolveGatsbyImageData),
+      },
 
-    resolvers.ShopifyProductFeaturedImage = {
-      gatsbyImageData: getGatsbyImageResolver(resolveGatsbyImageData),
-    };
+      ShopifyProductFeaturedImage: {
+        gatsbyImageData: getGatsbyImageResolver(resolveGatsbyImageData),
+      },
 
-    resolvers.ShopifyCollectionImage = {
-      gatsbyImageData: getGatsbyImageResolver(resolveGatsbyImageData),
-    };
-  }
-
-  if (shopifyConnections.includes("collections")) {
-    resolvers.ShopifyCollection = {
-      products: {
-        type: ["ShopifyProduct"],
-        resolve(source: any, _args: any, context: any, _info: any) {
-          return context.nodeModel.runQuery({
-            query: {
-              filter: {
-                id: { in: source.productIds || [] },
-              },
-            },
-            type: "ShopifyProduct",
-            firstOnly: false,
-          });
-        },
+      ShopifyCollectionImage: {
+        gatsbyImageData: getGatsbyImageResolver(resolveGatsbyImageData),
       },
     };
-  }
 
-  createResolvers(resolvers);
+    createResolvers(resolvers);
+  }
 }
 
 interface ErrorContext {

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -106,7 +106,7 @@ function makeSourceFromOperation(
 
       await Promise.all(
         op
-          .process(objects, nodeBuilder(gatsbyApi, options))
+          .process(objects, nodeBuilder(gatsbyApi, options), gatsbyApi)
           .map(async (promise) => {
             const node = await promise;
             actions.createNode(node);
@@ -374,7 +374,7 @@ export function createResolvers(
           return context.nodeModel.runQuery({
             query: {
               filter: {
-                shopifyId: { in: source.productIds || [] },
+                id: { in: source.productIds || [] },
               },
             },
             type: "ShopifyProduct",
@@ -391,7 +391,7 @@ export function createResolvers(
           return context.nodeModel.runQuery({
             query: {
               filter: {
-                productIds: { eq: source.shopifyId },
+                productIds: { eq: source.id },
               },
             },
             type: "ShopifyCollection",

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -309,6 +309,7 @@ export function createSchemaCustomization({
     type ShopifyProduct implements Node {
       variants: [ShopifyProductVariant] @link(from: "id", by: "productId")
       images: [ShopifyProductImage] @link(from: "id", by: "productId")
+      collections: [ShopifyCollection] @link(from: "id", by: "productIds")
     }
 
     type ShopifyProductFeaturedImage {
@@ -378,23 +379,6 @@ export function createResolvers(
               },
             },
             type: "ShopifyProduct",
-            firstOnly: false,
-          });
-        },
-      },
-    };
-
-    resolvers.ShopifyProduct = {
-      collections: {
-        type: ["ShopifyCollection"],
-        resolve(source: any, _args: any, context: any) {
-          return context.nodeModel.runQuery({
-            query: {
-              filter: {
-                productIds: { eq: source.id },
-              },
-            },
-            type: "ShopifyCollection",
             firstOnly: false,
           });
         },

--- a/plugin/src/node-builder.ts
+++ b/plugin/src/node-builder.ts
@@ -76,10 +76,12 @@ async function processChildImage(
 }
 
 const processorMap: ProcessorMap = {
-  LineItem: async (node) => {
+  LineItem: async (node, gatsbyApi) => {
     const lineItem = node;
     if (lineItem.product) {
-      lineItem.productId = (lineItem.product as BulkResult).id;
+      lineItem.productId = gatsbyApi.createNodeId(
+        (lineItem.product as BulkResult).id
+      );
       delete lineItem.product;
     }
   },

--- a/plugin/src/node-builder.ts
+++ b/plugin/src/node-builder.ts
@@ -4,12 +4,12 @@ import { createRemoteFileNode } from "gatsby-source-filesystem";
 // 'gid://shopify/Metafield/6936247730264'
 export const pattern = /^gid:\/\/shopify\/(\w+)\/(.+)$/;
 
-function attachParentId(obj: Record<string, any>) {
+function attachParentId(obj: Record<string, any>, gatsbyApi: SourceNodesArgs) {
   if (obj.__parentId) {
     const [fullId, remoteType] = obj.__parentId.match(pattern) || [];
     const field = remoteType.charAt(0).toLowerCase() + remoteType.slice(1);
     const idField = `${field}Id`;
-    obj[idField] = fullId;
+    obj[idField] = gatsbyApi.createNodeId(fullId);
     delete obj.__parentId;
   }
 }
@@ -121,7 +121,7 @@ export function nodeBuilder(
 
       const processor = processorMap[remoteType] || (() => Promise.resolve());
 
-      attachParentId(result);
+      attachParentId(result, gatsbyApi);
 
       const node = {
         ...result,

--- a/plugin/src/operations.ts
+++ b/plugin/src/operations.ts
@@ -37,7 +37,8 @@ export interface ShopifyBulkOperation {
   name: string;
   process: (
     objects: BulkResults,
-    nodeBuilder: NodeBuilder
+    nodeBuilder: NodeBuilder,
+    gatsbyApi: SourceNodesArgs
   ) => Promise<NodeInput>[];
 }
 
@@ -76,10 +77,7 @@ export function createOperations(
   function createOperation(
     operationQuery: string,
     name: string,
-    process?: (
-      objects: BulkResults,
-      nodeBuilder: NodeBuilder
-    ) => Promise<NodeInput>[]
+    process?: ShopifyBulkOperation["process"]
   ): ShopifyBulkOperation {
     return {
       execute: () =>

--- a/plugin/src/processors.ts
+++ b/plugin/src/processors.ts
@@ -1,9 +1,10 @@
-import { NodeInput } from "gatsby";
+import { NodeInput, SourceNodesArgs } from "gatsby";
 import { pattern as idPattern } from "./node-builder";
 
 export function collectionsProcessor(
   objects: BulkResults,
-  builder: NodeBuilder
+  builder: NodeBuilder,
+  gatsbyApi: SourceNodesArgs
 ): Promise<NodeInput>[] {
   const promises = [];
 
@@ -26,7 +27,7 @@ export function collectionsProcessor(
          * products all the way up until we get to the parent collection.
          */
         if (siblingRemoteType === `Product`) {
-          productIds.push(siblingId);
+          productIds.push(gatsbyApi.createNodeId(siblingId));
         }
 
         j--;
@@ -41,7 +42,9 @@ export function collectionsProcessor(
       promises.push(builder.buildNode(collection));
 
       const nextSlice = objects.slice(0, j);
-      return promises.concat(collectionsProcessor(nextSlice, builder));
+      return promises.concat(
+        collectionsProcessor(nextSlice, builder, gatsbyApi)
+      );
     } else {
       promises.push(builder.buildNode(result));
     }


### PR DESCRIPTION
All our one-to-many relationships were previously defined with custom resolvers, but these aren't necessary when we use Gatsby IDs to do the linking.

This adds `createNodeId` calls around the locations where we create the links, allowing us to replace each custom resolver with a `@link` directive.

Some things to test:

- [x] You can query a product's variants
- [x] You can query a product's collections
- [x] You can query a product's images
- [x] You can query a variant's product
- [x] You can query a variant's metafields
- [x] You can query a collection's products
- [x] You can query an order's line items
- [x] You can query a line item's product
- [x] You can query a line item's order