### PR TITLE
Add EXPIRED to list of finished statuses

### DIFF
--- a/plugin/src/operations.ts
+++ b/plugin/src/operations.ts
@@ -57,7 +57,7 @@ interface CurrentBulkOperationResponse {
   };
 }
 
-const finishedStatuses = [`COMPLETED`, `FAILED`, `CANCELED`];
+const finishedStatuses = [`COMPLETED`, `FAILED`, `CANCELED`, `EXPIRED`];
 
 function defaultProcessor(objects: BulkResults, builder: NodeBuilder) {
   return objects.map(builder.buildNode);


### PR DESCRIPTION
If an app's previous operation was more than 7 days ago, it will be marked as expired since the results are no longer available. This adds the `EXPIRED` status to a list of finished statuses so that awaiting an operation in progress will not wait for expired operations.