### PR TITLE
Feature/variant image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,6 @@ jobs:
       - name: Run tests
         working-directory: ./plugin
         run: yarn test --coverage
-      - name: Uplaod coverage reports
+      - name: Upload coverage reports
         uses: codecov/codecov-action@v1
         if: matrix.node-version == '12.x'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-source-shopify-workspace",
+  "name": "gatsby-source-shopify-experimental",
   "private": "true",
   "workspaces": [
     "./plugin",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-source-shopify-experimental",
+  "name": "gatsby-source-shopify-workspace",
   "private": "true",
   "workspaces": [
     "./plugin",

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -71,6 +71,7 @@ const shopifyNodeTypes = [
   `ShopifyCollectionImage`,
   `ShopifyProductFeaturedImage`,
   `ShopifyProductVariant`,
+  `ShopifyProductVariantImage`,
   `ShopifyProductVariantPricePair`,
 ];
 
@@ -184,6 +185,10 @@ export function createSchemaCustomization({
     type ShopifyProductVariant implements Node {
       product: ShopifyProduct @link(from: "productId", by: "id")
       metafields: [ShopifyMetafield] @link(from: "id", by: "productVariantId")
+    }
+
+    type ShopifyProductVariantImage {
+      localFile: File @link
     }
 
     type ShopifyProduct implements Node {

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -248,6 +248,10 @@ export function createResolvers(
       ShopifyCollectionImage: {
         gatsbyImageData: getGatsbyImageResolver(resolveGatsbyImageData),
       },
+
+      ShopifyProductVariantImage: {
+        gatsbyImageData: getGatsbyImageResolver(resolveGatsbyImageData),
+      },
     };
 
     createResolvers(resolvers);

--- a/plugin/src/node-builder.ts
+++ b/plugin/src/node-builder.ts
@@ -75,7 +75,7 @@ async function processChildImage(
   }
 }
 
-const processorMap: ProcessorMap = {
+export const processorMap: ProcessorMap = {
   LineItem: async (node, gatsbyApi) => {
     const lineItem = node;
     if (lineItem.product) {

--- a/plugin/src/node-builder.ts
+++ b/plugin/src/node-builder.ts
@@ -105,6 +105,9 @@ const processorMap: ProcessorMap = {
   Product: async (node, gatsbyApi, options) => {
     return processChildImage(node, "featuredImage", gatsbyApi, options);
   },
+  ProductVariant: async (node, gatsbyApi, options) => {
+    return processChildImage(node, "media", gatsbyApi, options);
+  },
 };
 
 export function nodeBuilder(

--- a/plugin/src/node-builder.ts
+++ b/plugin/src/node-builder.ts
@@ -106,7 +106,7 @@ const processorMap: ProcessorMap = {
     return processChildImage(node, "featuredImage", gatsbyApi, options);
   },
   ProductVariant: async (node, gatsbyApi, options) => {
-    return processChildImage(node, "media", gatsbyApi, options);
+    return processChildImage(node, "image", gatsbyApi, options);
   },
 };
 

--- a/plugin/src/queries.ts
+++ b/plugin/src/queries.ts
@@ -316,6 +316,14 @@ const productsQuery = (dateString?: string) => {
                       }
                     }
                   }
+                  media {
+                    id
+                    altText
+                    height
+                    width
+                    originalSrc
+                    transformedSrc
+                  }
                 }
               }
             }

--- a/plugin/src/queries.ts
+++ b/plugin/src/queries.ts
@@ -316,7 +316,7 @@ const productsQuery = (dateString?: string) => {
                       }
                     }
                   }
-                  media {
+                  image {
                     id
                     altText
                     height

--- a/plugin/test/node-builder.spec.ts
+++ b/plugin/test/node-builder.spec.ts
@@ -1,0 +1,89 @@
+import { setupServer } from "msw/node";
+import { SourceNodesArgs, NodeInput } from "gatsby";
+
+import { processorMap } from "../src/node-builder"
+
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen();
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe("When a variant has an image set", () => {
+  const node = {
+    image: {
+      id: "foo1",
+      originalSrc: "https://via.placeholder.com/100x100",
+    },
+    id: "foo2", 
+    internal: {
+      type: "foo3", 
+      contentDigest: "foo4", 
+    }
+  } as NodeInput
+
+  const createNode = jest.fn();
+  const gatsbyApiMock = jest.fn().mockImplementation(() => {
+    return {
+      cache: {
+        set: jest.fn(),
+        get: jest.fn(),
+      },
+      actions: {
+        createNode,
+      },
+      createContentDigest: jest.fn(),
+      createNodeId: jest.fn(),
+      store: jest.fn(),
+      reporter: {
+        info: jest.fn(),
+        error: jest.fn(),
+        panic: jest.fn(),
+        activityTimer: () => ({
+          start: jest.fn(),
+          end: jest.fn(),
+          setStatus: jest.fn(),
+        }),
+      },
+    };
+  });
+
+  const gatsbyApi = gatsbyApiMock as jest.Mock<SourceNodesArgs>;
+
+  describe("and options are set, not to download images", () => {
+    const options = {
+      apiKey: ``,
+      password: ``,
+      storeUrl: "my-shop.shopify.com",
+    };
+
+    it("doesn't create localFile on the node.", async () => {
+      await processorMap.ProductVariant(node, gatsbyApi(), options);
+      expect(node).not.toHaveProperty('localFile');
+    })
+  })
+
+  /*
+  describe("and options are set to download images", () => {
+    const options = {
+      apiKey: ``,
+      password: ``,
+      storeUrl: "my-shop.shopify.com",
+      downloadImages: true,
+    };
+
+    it("creates localFile on the node.", async () => {
+      await processorMap.ProductVariant(node, gatsbyApi(), options);
+      expect(node).toHaveProperty('localFile');
+    })
+  });
+  */
+});


### PR DESCRIPTION
fixes https://github.com/gatsbyjs/gatsby-source-shopify-experimental/issues/62

The `ProductVariant` alread has a field called `image` with an `Image` resource (see https://shopify.dev/docs/admin-api/graphql/reference/products-and-collections/productvariant#image-2021-01), so I just added the mapping similar to the other cases.

This is my first PR to a Gatsby source plugin, so I'm not 100% sure this already suffices. Tested it with the steps described in [Development](https://github.com/gatsbyjs/gatsby-source-shopify-experimental#development) and saw it working correctly in the local GraphiQL explorer.

![productVariantImage](https://user-images.githubusercontent.com/2728418/111135142-99573400-857c-11eb-8a80-373024657561.jpg)
