### PR TITLE
:sparkles: Add metafields to collection

### DIFF
--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -194,6 +194,7 @@ export function createSchemaCustomization({
 
     type ShopifyCollection implements Node {
       products: [ShopifyProduct] @link(from: "productIds", by: "id")
+      metafields: [ShopifyMetafield] @link(from: "id", by: "collectionId")
     }
 
     type ShopifyProductFeaturedImage {
@@ -202,10 +203,6 @@ export function createSchemaCustomization({
 
     type ShopifyCollectionImage {
       localFile: File @link
-    }
-
-    type ShopifyMetafield implements Node {
-      productVariant: ShopifyProductVariant @link(from: "productVariantId", by: "id")
     }
 
     type ShopifyOrder implements Node {

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -205,6 +205,11 @@ export function createSchemaCustomization({
       localFile: File @link
     }
 
+    type ShopifyMetafield implements Node {
+      productVariant: ShopifyProductVariant @link(from: "productVariantId", by: "id")
+      collection: ShopifyCollection @link(from: "collectionId", by: "id")
+    }
+
     type ShopifyOrder implements Node {
       lineItems: [ShopifyLineItem] @link(from: "id", by: "orderId")
     }

--- a/plugin/src/queries.ts
+++ b/plugin/src/queries.ts
@@ -132,6 +132,18 @@ const collectionsQuery = (dateString?: string) => `
         templateSuffix
         title
         updatedAt
+        metafields {
+          edges {
+            node {
+              description
+              id
+              key
+              namespace
+              value
+              valueType
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
fixes https://github.com/gatsbyjs/gatsby-source-shopify-experimental/issues/81

![collectionmetafields](https://user-images.githubusercontent.com/2728418/111441758-eb789080-8707-11eb-92f8-465c85620120.png)

Seems to work already like this.