### PR TITLE
Use type builders to customize schema

### DIFF
--- a/plugin/src/create-schema-customization.ts
+++ b/plugin/src/create-schema-customization.ts
@@ -24,43 +24,45 @@ export function createSchemaCustomization(
   //   productImageFields.localFile = `File @link`;
   // }
 
-  const typeDefs = [
-    schema.buildObjectType({
-      name: "ShopifyProduct",
-      fields: {
-        // collections: includeCollections ? {
-        //   type: "[ShopifyCollection]",
-        //   extensions: {
-        //     directives: [{
-        //       name: "link",
-        //       args: {
-        //         from: "id",
-        //         by: "productIds"
-        //       }
-        //     }]
-        //   }
-        // } : undefined,
-        variants: {
-          type: "[ShopifyProductVariant]",
-          extensions: {
-            link: {
-              from: "id",
-              by: "productId",
-            },
-          },
-        },
-        images: {
-          type: "[ShopifyProductImage]",
-          extensions: {
-            link: {
-              from: "id",
-              by: "productId",
-            },
+  const productDef = schema.buildObjectType({
+    name: "ShopifyProduct",
+    fields: {
+      variants: {
+        type: "[ShopifyProductVariant]",
+        extensions: {
+          link: {
+            from: "id",
+            by: "productId",
           },
         },
       },
-      interfaces: ["Node"],
-    }),
+      images: {
+        type: "[ShopifyProductImage]",
+        extensions: {
+          link: {
+            from: "id",
+            by: "productId",
+          },
+        },
+      },
+    },
+    interfaces: ["Node"],
+  });
+
+  if (includeCollections && productDef.config.fields) {
+    productDef.config.fields.collections = {
+      type: "[ShopifyCollection]",
+      extensions: {
+        link: {
+          from: "id",
+          by: "productIds",
+        },
+      },
+    };
+  }
+
+  const typeDefs = [
+    productDef,
     schema.buildObjectType({
       name: "ShopifyProductImage",
       fields: {

--- a/plugin/src/create-schema-customization.ts
+++ b/plugin/src/create-schema-customization.ts
@@ -51,6 +51,31 @@ export function createSchemaCustomization(
     interfaces: ["Node"],
   });
 
+  const productImageDef = schema.buildObjectType({
+    name: name("ShopifyProductImage"),
+    fields: {
+      product: {
+        type: "ShopifyProduct!",
+        extensions: {
+          link: {
+            from: "productId",
+            by: "id",
+          },
+        },
+      },
+    },
+    interfaces: ["Node"],
+  });
+
+  if (pluginOptions.downloadImages && productImageDef.config.fields) {
+    productImageDef.config.fields.localFile = {
+      type: "File",
+      extensions: {
+        link: {},
+      },
+    };
+  }
+
   if (includeCollections && productDef.config.fields) {
     productDef.config.fields.collections = {
       type: `[${name("ShopifyCollection")}]`,
@@ -65,21 +90,7 @@ export function createSchemaCustomization(
 
   const typeDefs = [
     productDef,
-    schema.buildObjectType({
-      name: name("ShopifyProductImage"),
-      fields: {
-        product: {
-          type: "ShopifyProduct!",
-          extensions: {
-            link: {
-              from: "productId",
-              by: "id",
-            },
-          },
-        },
-      },
-      interfaces: ["Node"],
-    }),
+    productImageDef,
     schema.buildObjectType({
       name: name("ShopifyProductVariant"),
       fields: {

--- a/plugin/src/create-schema-customization.ts
+++ b/plugin/src/create-schema-customization.ts
@@ -1,0 +1,225 @@
+import { CreateSchemaCustomizationArgs } from "gatsby";
+
+export function createSchemaCustomization(
+  { actions, schema }: CreateSchemaCustomizationArgs,
+  pluginOptions: ShopifyPluginOptions
+) {
+  const includeCollections =
+    pluginOptions.shopifyConnections &&
+    pluginOptions.shopifyConnections.includes("collections");
+
+  // const includeOrders =
+  //   pluginOptions.shopifyConnections &&
+  //   pluginOptions.shopifyConnections.includes("orders");
+
+  // const productImageFields: Fields = {
+  //   product: {
+  //     type: "ShopifyProduct",
+  //
+  //   }
+  //   //product: `ShopifyProduct @link(from: "productId", by: "id")`,
+  // };
+
+  // if (pluginOptions.downloadImages) {
+  //   productImageFields.localFile = `File @link`;
+  // }
+
+  const typeDefs = [
+    schema.buildObjectType({
+      name: "ShopifyProduct",
+      fields: {
+        // collections: includeCollections ? {
+        //   type: "[ShopifyCollection]",
+        //   extensions: {
+        //     directives: [{
+        //       name: "link",
+        //       args: {
+        //         from: "id",
+        //         by: "productIds"
+        //       }
+        //     }]
+        //   }
+        // } : undefined,
+        variants: {
+          type: "[ShopifyProductVariant]",
+          extensions: {
+            directives: [
+              {
+                name: "@link",
+                args: {
+                  from: "id",
+                  by: "productId",
+                },
+              },
+            ],
+          },
+        },
+        images: {
+          type: "[ShopifyProductImage]",
+          extensions: {
+            directives: [
+              {
+                name: "link",
+                args: {
+                  from: "id",
+                  by: "productId",
+                },
+              },
+            ],
+          },
+        },
+      },
+      interfaces: ["Node"],
+    }),
+    schema.buildObjectType({
+      name: "ShopifyProductImage",
+      fields: {
+        product: {
+          type: "ShopifyProduct!",
+          extensions: {
+            directives: [
+              {
+                name: "link",
+                args: {
+                  from: "productId",
+                  by: "id",
+                },
+              },
+            ],
+          },
+        },
+      },
+      interfaces: ["Node"],
+    }),
+    schema.buildObjectType({
+      name: "ShopifyProductVariant",
+      fields: {
+        product: {
+          type: "ShopifyProduct",
+          extensions: {
+            directives: [
+              {
+                name: "link",
+                args: {
+                  from: "productId",
+                  by: "id",
+                },
+              },
+            ],
+          },
+        },
+        metafields: {
+          type: `[ShopifyMetafield]`,
+          extensions: {
+            directives: [
+              {
+                name: "link",
+                args: {
+                  from: "id",
+                  by: "productVariantId",
+                },
+              },
+            ],
+          },
+        },
+      },
+      interfaces: ["Node"],
+    }),
+    /**
+     * FIXME: let's change this to e.g. ShopifyProductVariantMetafield,
+     * because we will want metafields attached to other resource types
+     * as well. This will need to come with a change in node creation logic
+     * where the type name is partially derived from the parent ID.
+     */
+    schema.buildObjectType({
+      name: "ShopifyMetafield",
+      fields: {
+        productVariant: {
+          type: "ShopifyProductVariant!",
+          extensions: {
+            directives: [
+              {
+                name: "link",
+                args: {
+                  from: "productVariantId",
+                  by: "id",
+                },
+              },
+            ],
+          },
+        },
+      },
+      interfaces: ["Node"],
+    }),
+  ];
+
+  if (includeCollections) {
+    typeDefs.push(
+      schema.buildObjectType({
+        name: "ShopifyCollection",
+        fields: {
+          products: {
+            type: "[ShopifyProduct]",
+            extensions: {
+              directives: [
+                {
+                  name: "link",
+                  args: {
+                    from: "productIds",
+                    by: "id",
+                  },
+                },
+              ],
+            },
+          },
+        },
+        interfaces: ["Node"],
+      })
+    );
+  }
+
+  // if (includeOrders) {
+  //   typeDefs.push(
+  //     schema.buildObjectType({
+  //       name: "ShopifyOrder",
+  //       fields: {
+  //         lineItems: `[ShopifyLineItem] @link(from: "id", by: "orderId")`,
+  //       },
+  //       interfaces: ["Node"],
+  //     }),
+  //     schema.buildObjectType({
+  //       name: "ShopifyLineItem",
+  //       fields: {
+  //         product: `ShopifyProduct @link(from: "productId", by: "id")`,
+  //         order: `ShopifyOrder! @link(from: "orderId", by: "id")`,
+  //       },
+  //     })
+  //   );
+  // }
+
+  // if (pluginOptions.downloadImages) {
+  //   typeDefs.push(
+  //     schema.buildObjectType({
+  //       name: "ShopifyProductFeaturedImage",
+  //       fields: {
+  //         localFile: `File @link`,
+  //       },
+  //       interfaces: ["Node"],
+  //     })
+  //   );
+
+  //   if (includeCollections) {
+  //     typeDefs.push(
+  //       schema.buildObjectType({
+  //         name: "ShopifyCollectionImage",
+  //         fields: {
+  //           localFile: `File @link`,
+  //         },
+  //         interfaces: ["Node"],
+  //       })
+  //     );
+  //   }
+  // }
+
+  actions.createTypes(typeDefs);
+}

--- a/plugin/src/create-schema-customization.ts
+++ b/plugin/src/create-schema-customization.ts
@@ -8,21 +8,9 @@ export function createSchemaCustomization(
     pluginOptions.shopifyConnections &&
     pluginOptions.shopifyConnections.includes("collections");
 
-  // const includeOrders =
-  //   pluginOptions.shopifyConnections &&
-  //   pluginOptions.shopifyConnections.includes("orders");
-
-  // const productImageFields: Fields = {
-  //   product: {
-  //     type: "ShopifyProduct",
-  //
-  //   }
-  //   //product: `ShopifyProduct @link(from: "productId", by: "id")`,
-  // };
-
-  // if (pluginOptions.downloadImages) {
-  //   productImageFields.localFile = `File @link`;
-  // }
+  const includeOrders =
+    pluginOptions.shopifyConnections &&
+    pluginOptions.shopifyConnections.includes("orders");
 
   const name = (name: string) => `${pluginOptions.typePrefix}${name}`;
 
@@ -55,7 +43,7 @@ export function createSchemaCustomization(
     name: name("ShopifyProductImage"),
     fields: {
       product: {
-        type: "ShopifyProduct!",
+        type: name("ShopifyProduct!"),
         extensions: {
           link: {
             from: "productId",
@@ -158,48 +146,83 @@ export function createSchemaCustomization(
     );
   }
 
-  // if (includeOrders) {
-  //   typeDefs.push(
-  //     schema.buildObjectType({
-  //       name: "ShopifyOrder",
-  //       fields: {
-  //         lineItems: `[ShopifyLineItem] @link(from: "id", by: "orderId")`,
-  //       },
-  //       interfaces: ["Node"],
-  //     }),
-  //     schema.buildObjectType({
-  //       name: "ShopifyLineItem",
-  //       fields: {
-  //         product: `ShopifyProduct @link(from: "productId", by: "id")`,
-  //         order: `ShopifyOrder! @link(from: "orderId", by: "id")`,
-  //       },
-  //     })
-  //   );
-  // }
+  if (includeOrders) {
+    typeDefs.push(
+      schema.buildObjectType({
+        name: name("ShopifyOrder"),
+        fields: {
+          lineItems: {
+            type: `[${name("ShopifyLineItem")}]`,
+            extensions: {
+              link: {
+                from: "id",
+                by: "orderId",
+              },
+            },
+          },
+        },
+        interfaces: ["Node"],
+      }),
+      schema.buildObjectType({
+        name: name("ShopifyLineItem"),
+        fields: {
+          product: {
+            type: name("ShopifyProduct"),
+            extensions: {
+              link: {
+                from: "productId",
+                by: "id",
+              },
+            },
+          },
+          order: {
+            type: name("ShopifyOrder!"),
+            extensions: {
+              link: {
+                from: "orderId",
+                by: "id",
+              },
+            },
+          },
+        },
+        interfaces: ["Node"],
+      })
+    );
+  }
 
-  // if (pluginOptions.downloadImages) {
-  //   typeDefs.push(
-  //     schema.buildObjectType({
-  //       name: "ShopifyProductFeaturedImage",
-  //       fields: {
-  //         localFile: `File @link`,
-  //       },
-  //       interfaces: ["Node"],
-  //     })
-  //   );
+  if (pluginOptions.downloadImages) {
+    typeDefs.push(
+      schema.buildObjectType({
+        name: name("ShopifyProductFeaturedImage"),
+        fields: {
+          localFile: {
+            type: "File",
+            extensions: {
+              link: {},
+            },
+          },
+        },
+        interfaces: ["Node"],
+      })
+    );
 
-  //   if (includeCollections) {
-  //     typeDefs.push(
-  //       schema.buildObjectType({
-  //         name: "ShopifyCollectionImage",
-  //         fields: {
-  //           localFile: `File @link`,
-  //         },
-  //         interfaces: ["Node"],
-  //       })
-  //     );
-  //   }
-  // }
+    if (includeCollections) {
+      typeDefs.push(
+        schema.buildObjectType({
+          name: name("ShopifyCollectionImage"),
+          fields: {
+            localFile: {
+              type: "File",
+              extensions: {
+                link: {},
+              },
+            },
+          },
+          interfaces: ["Node"],
+        })
+      );
+    }
+  }
 
   actions.createTypes(typeDefs);
 }

--- a/plugin/src/create-schema-customization.ts
+++ b/plugin/src/create-schema-customization.ts
@@ -4,13 +4,11 @@ export function createSchemaCustomization(
   { actions, schema }: CreateSchemaCustomizationArgs,
   pluginOptions: ShopifyPluginOptions
 ) {
-  const includeCollections =
-    pluginOptions.shopifyConnections &&
-    pluginOptions.shopifyConnections.includes("collections");
+  const includeCollections = pluginOptions.shopifyConnections?.includes(
+    "collections"
+  );
 
-  const includeOrders =
-    pluginOptions.shopifyConnections &&
-    pluginOptions.shopifyConnections.includes("orders");
+  const includeOrders = pluginOptions.shopifyConnections?.includes("orders");
 
   const name = (name: string) => `${pluginOptions.typePrefix}${name}`;
 

--- a/plugin/src/create-schema-customization.ts
+++ b/plugin/src/create-schema-customization.ts
@@ -24,11 +24,13 @@ export function createSchemaCustomization(
   //   productImageFields.localFile = `File @link`;
   // }
 
+  const name = (name: string) => `${pluginOptions.typePrefix}${name}`;
+
   const productDef = schema.buildObjectType({
-    name: "ShopifyProduct",
+    name: name("ShopifyProduct"),
     fields: {
       variants: {
-        type: "[ShopifyProductVariant]",
+        type: `[${name("ShopifyProductVariant")}]`,
         extensions: {
           link: {
             from: "id",
@@ -37,7 +39,7 @@ export function createSchemaCustomization(
         },
       },
       images: {
-        type: "[ShopifyProductImage]",
+        type: `[${name("ShopifyProductImage")}]`,
         extensions: {
           link: {
             from: "id",
@@ -51,7 +53,7 @@ export function createSchemaCustomization(
 
   if (includeCollections && productDef.config.fields) {
     productDef.config.fields.collections = {
-      type: "[ShopifyCollection]",
+      type: `[${name("ShopifyCollection")}]`,
       extensions: {
         link: {
           from: "id",
@@ -64,7 +66,7 @@ export function createSchemaCustomization(
   const typeDefs = [
     productDef,
     schema.buildObjectType({
-      name: "ShopifyProductImage",
+      name: name("ShopifyProductImage"),
       fields: {
         product: {
           type: "ShopifyProduct!",
@@ -79,10 +81,10 @@ export function createSchemaCustomization(
       interfaces: ["Node"],
     }),
     schema.buildObjectType({
-      name: "ShopifyProductVariant",
+      name: name("ShopifyProductVariant"),
       fields: {
         product: {
-          type: "ShopifyProduct",
+          type: name("ShopifyProduct!"),
           extensions: {
             link: {
               from: "productId",
@@ -91,7 +93,7 @@ export function createSchemaCustomization(
           },
         },
         metafields: {
-          type: `[ShopifyMetafield]`,
+          type: `[${name("ShopifyMetafield")}]`,
           extensions: {
             link: {
               from: "id",
@@ -109,10 +111,10 @@ export function createSchemaCustomization(
      * where the type name is partially derived from the parent ID.
      */
     schema.buildObjectType({
-      name: "ShopifyMetafield",
+      name: name("ShopifyMetafield"),
       fields: {
         productVariant: {
-          type: "ShopifyProductVariant!",
+          type: name("ShopifyProductVariant!"),
           extensions: {
             link: {
               from: "productVariantId",
@@ -128,10 +130,10 @@ export function createSchemaCustomization(
   if (includeCollections) {
     typeDefs.push(
       schema.buildObjectType({
-        name: "ShopifyCollection",
+        name: name("ShopifyCollection"),
         fields: {
           products: {
-            type: "[ShopifyProduct]",
+            type: `[${name("ShopifyProduct")}]`,
             extensions: {
               link: {
                 from: "productIds",

--- a/plugin/src/create-schema-customization.ts
+++ b/plugin/src/create-schema-customization.ts
@@ -43,29 +43,19 @@ export function createSchemaCustomization(
         variants: {
           type: "[ShopifyProductVariant]",
           extensions: {
-            directives: [
-              {
-                name: "@link",
-                args: {
-                  from: "id",
-                  by: "productId",
-                },
-              },
-            ],
+            link: {
+              from: "id",
+              by: "productId",
+            },
           },
         },
         images: {
           type: "[ShopifyProductImage]",
           extensions: {
-            directives: [
-              {
-                name: "link",
-                args: {
-                  from: "id",
-                  by: "productId",
-                },
-              },
-            ],
+            link: {
+              from: "id",
+              by: "productId",
+            },
           },
         },
       },
@@ -77,15 +67,10 @@ export function createSchemaCustomization(
         product: {
           type: "ShopifyProduct!",
           extensions: {
-            directives: [
-              {
-                name: "link",
-                args: {
-                  from: "productId",
-                  by: "id",
-                },
-              },
-            ],
+            link: {
+              from: "productId",
+              by: "id",
+            },
           },
         },
       },
@@ -97,29 +82,19 @@ export function createSchemaCustomization(
         product: {
           type: "ShopifyProduct",
           extensions: {
-            directives: [
-              {
-                name: "link",
-                args: {
-                  from: "productId",
-                  by: "id",
-                },
-              },
-            ],
+            link: {
+              from: "productId",
+              by: "id",
+            },
           },
         },
         metafields: {
           type: `[ShopifyMetafield]`,
           extensions: {
-            directives: [
-              {
-                name: "link",
-                args: {
-                  from: "id",
-                  by: "productVariantId",
-                },
-              },
-            ],
+            link: {
+              from: "id",
+              by: "productVariantId",
+            },
           },
         },
       },
@@ -137,15 +112,10 @@ export function createSchemaCustomization(
         productVariant: {
           type: "ShopifyProductVariant!",
           extensions: {
-            directives: [
-              {
-                name: "link",
-                args: {
-                  from: "productVariantId",
-                  by: "id",
-                },
-              },
-            ],
+            link: {
+              from: "productVariantId",
+              by: "id",
+            },
           },
         },
       },
@@ -161,15 +131,10 @@ export function createSchemaCustomization(
           products: {
             type: "[ShopifyProduct]",
             extensions: {
-              directives: [
-                {
-                  name: "link",
-                  args: {
-                    from: "productIds",
-                    by: "id",
-                  },
-                },
-              ],
+              link: {
+                from: "productIds",
+                by: "id",
+              },
             },
           },
         },

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -195,57 +195,6 @@ export async function sourceNodes(
   );
 }
 
-// export function createSchemaCustomization({
-//   actions,
-// }: CreateSchemaCustomizationArgs, {
-//   typePrefix
-// }: ShopifyPluginOptions) {
-//   actions.createTypes(`
-//     type ${typePrefix}ShopifyProductVariant implements Node {
-//       product: ${typePrefix}ShopifyProduct @link(from: "productId", by: "id")
-//       metafields: [${typePrefix}ShopifyMetafield] @link(from: "id", by: "productVariantId")
-//     }
-//
-//     type ${typePrefix}ShopifyProduct implements Node {
-//       variants: [${typePrefix}ShopifyProductVariant] @link(from: "id", by: "productId")
-//       images: [${typePrefix}ShopifyProductImage] @link(from: "id", by: "productId")
-//       collections: [${typePrefix}ShopifyCollection] @link(from: "id", by: "productIds")
-//     }
-//
-//     type ${typePrefix}ShopifyCollection implements Node {
-//       products: [${typePrefix}ShopifyProduct] @link(from: "productIds", by: "id")
-//     }
-//
-//     type ${typePrefix}ShopifyProductFeaturedImage {
-//       localFile: File @link
-//     }
-//
-//     type ${typePrefix}ShopifyCollectionImage {
-//       localFile: File @link
-//     }
-//
-//     type ${typePrefix}ShopifyMetafield implements Node {
-//       productVariant: ${typePrefix}ShopifyProductVariant @link(from: "productVariantId", by: "id")
-//     }
-//
-//     type ${typePrefix}ShopifyOrder implements Node {
-//       lineItems: [${typePrefix}ShopifyLineItem] @link(from: "id", by: "orderId")
-//     }
-//
-//     type ${typePrefix}ShopifyLineItem implements Node {
-//       product: ${typePrefix}ShopifyProduct @link(from: "productId", by: "id")
-//       order: ${typePrefix}ShopifyOrder @link(from: "orderId", by: "id")
-//     }
-//
-//     type ${typePrefix}ShopifyProductImage implements Node {
-//       altText: String
-//       originalSrc: String!
-//       product: ${typePrefix}ShopifyProduct @link(from: "productId", by: "id")
-//       localFile: File @link
-//     }
-//   `);
-// }
-
 export function createResolvers(
   { createResolvers }: CreateResolversArgs,
   { downloadImages, typePrefix }: ShopifyPluginOptions

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -2,7 +2,6 @@ import { createOperations } from "./operations";
 import { eventsApi } from "./events";
 import {
   CreateResolversArgs,
-  CreateSchemaCustomizationArgs,
   NodePluginArgs,
   PluginOptionsSchemaArgs,
   SourceNodesArgs,
@@ -12,6 +11,7 @@ import { resolveGatsbyImageData } from "./resolve-gatsby-image-data";
 import { pluginErrorCodes as errorCodes } from "./errors";
 import { LAST_SHOPIFY_BULK_OPERATION } from "./constants";
 import { makeSourceFromOperation } from "./make-source-from-operation";
+export { createSchemaCustomization } from "./create-schema-customization";
 
 export function pluginOptionsSchema({ Joi }: PluginOptionsSchemaArgs) {
   return Joi.object({
@@ -21,9 +21,11 @@ export function pluginOptionsSchema({ Joi }: PluginOptionsSchemaArgs) {
     downloadImages: Joi.boolean(),
     verboseLogging: Joi.boolean(),
     typePrefix: Joi.string()
-      .pattern(new RegExp('(^[A-Z]\w*)'))
-      .message('"typePrefix" can only be alphanumeric characters, starting with an uppercase letter')
-      .default(''),
+      .pattern(new RegExp("(^[A-Z]w*)"))
+      .message(
+        '"typePrefix" can only be alphanumeric characters, starting with an uppercase letter'
+      )
+      .default(""),
     shopifyConnections: Joi.array()
       .default([])
       .items(Joi.string().valid("orders", "collections")),
@@ -95,7 +97,7 @@ async function sourceChangedNodes(
       `gatsby-source-shopify-experimental`
     ]?.[`lastBuildTime${pluginOptions.typePrefix}`]
   );
-  
+
   for (const nodeType of shopifyNodeTypes) {
     gatsbyApi
       .getNodesByType(`${pluginOptions.typePrefix}${nodeType}`)
@@ -169,7 +171,8 @@ export async function sourceNodes(
     `gatsby-source-shopify-experimental`
   ];
 
-  const lastBuildTime = pluginStatus?.[`lastBuildTime${pluginOptions.typePrefix}`];
+  const lastBuildTime =
+    pluginStatus?.[`lastBuildTime${pluginOptions.typePrefix}`];
 
   if (lastBuildTime !== undefined) {
     gatsbyApi.reporter.info(`Cache is warm, running an incremental build`);
@@ -179,69 +182,69 @@ export async function sourceNodes(
     await sourceAllNodes(gatsbyApi, pluginOptions);
   }
 
-  gatsbyApi.reporter.info(`Finished sourcing nodes, caching last build time`);  
+  gatsbyApi.reporter.info(`Finished sourcing nodes, caching last build time`);
   gatsbyApi.actions.setPluginStatus(
     pluginStatus !== undefined
       ? {
           ...pluginStatus,
-          [`lastBuildTime${pluginOptions.typePrefix}`]: Date.now()
+          [`lastBuildTime${pluginOptions.typePrefix}`]: Date.now(),
         }
       : {
-          [`lastBuildTime${pluginOptions.typePrefix}`]: Date.now()
-        }  
+          [`lastBuildTime${pluginOptions.typePrefix}`]: Date.now(),
+        }
   );
 }
 
-export function createSchemaCustomization({
-  actions,
-}: CreateSchemaCustomizationArgs, {
-  typePrefix
-}: ShopifyPluginOptions) {
-  actions.createTypes(`
-    type ${typePrefix}ShopifyProductVariant implements Node {
-      product: ${typePrefix}ShopifyProduct @link(from: "productId", by: "id")
-      metafields: [${typePrefix}ShopifyMetafield] @link(from: "id", by: "productVariantId")
-    }
-
-    type ${typePrefix}ShopifyProduct implements Node {
-      variants: [${typePrefix}ShopifyProductVariant] @link(from: "id", by: "productId")
-      images: [${typePrefix}ShopifyProductImage] @link(from: "id", by: "productId")
-      collections: [${typePrefix}ShopifyCollection] @link(from: "id", by: "productIds")
-    }
-
-    type ${typePrefix}ShopifyCollection implements Node {
-      products: [${typePrefix}ShopifyProduct] @link(from: "productIds", by: "id")
-    }
-
-    type ${typePrefix}ShopifyProductFeaturedImage {
-      localFile: File @link
-    }
-
-    type ${typePrefix}ShopifyCollectionImage {
-      localFile: File @link
-    }
-
-    type ${typePrefix}ShopifyMetafield implements Node {
-      productVariant: ${typePrefix}ShopifyProductVariant @link(from: "productVariantId", by: "id")
-    }
-
-    type ${typePrefix}ShopifyOrder implements Node {
-      lineItems: [${typePrefix}ShopifyLineItem] @link(from: "id", by: "orderId")
-    }
-
-    type ${typePrefix}ShopifyLineItem implements Node {
-      product: ${typePrefix}ShopifyProduct @link(from: "productId", by: "id")
-      order: ${typePrefix}ShopifyOrder @link(from: "orderId", by: "id")
-    }
-
-    type ${typePrefix}ShopifyProductImage implements Node {
-      altText: String
-      originalSrc: String!
-      product: ${typePrefix}ShopifyProduct @link(from: "productId", by: "id")
-      localFile: File @link
-    }
-  `);
-}
+// export function createSchemaCustomization({
+//   actions,
+// }: CreateSchemaCustomizationArgs, {
+//   typePrefix
+// }: ShopifyPluginOptions) {
+//   actions.createTypes(`
+//     type ${typePrefix}ShopifyProductVariant implements Node {
+//       product: ${typePrefix}ShopifyProduct @link(from: "productId", by: "id")
+//       metafields: [${typePrefix}ShopifyMetafield] @link(from: "id", by: "productVariantId")
+//     }
+//
+//     type ${typePrefix}ShopifyProduct implements Node {
+//       variants: [${typePrefix}ShopifyProductVariant] @link(from: "id", by: "productId")
+//       images: [${typePrefix}ShopifyProductImage] @link(from: "id", by: "productId")
+//       collections: [${typePrefix}ShopifyCollection] @link(from: "id", by: "productIds")
+//     }
+//
+//     type ${typePrefix}ShopifyCollection implements Node {
+//       products: [${typePrefix}ShopifyProduct] @link(from: "productIds", by: "id")
+//     }
+//
+//     type ${typePrefix}ShopifyProductFeaturedImage {
+//       localFile: File @link
+//     }
+//
+//     type ${typePrefix}ShopifyCollectionImage {
+//       localFile: File @link
+//     }
+//
+//     type ${typePrefix}ShopifyMetafield implements Node {
+//       productVariant: ${typePrefix}ShopifyProductVariant @link(from: "productVariantId", by: "id")
+//     }
+//
+//     type ${typePrefix}ShopifyOrder implements Node {
+//       lineItems: [${typePrefix}ShopifyLineItem] @link(from: "id", by: "orderId")
+//     }
+//
+//     type ${typePrefix}ShopifyLineItem implements Node {
+//       product: ${typePrefix}ShopifyProduct @link(from: "productId", by: "id")
+//       order: ${typePrefix}ShopifyOrder @link(from: "orderId", by: "id")
+//     }
+//
+//     type ${typePrefix}ShopifyProductImage implements Node {
+//       altText: String
+//       originalSrc: String!
+//       product: ${typePrefix}ShopifyProduct @link(from: "productId", by: "id")
+//       localFile: File @link
+//     }
+//   `);
+// }
 
 export function createResolvers(
   { createResolvers }: CreateResolversArgs,

--- a/test-site/gatsby-config.js
+++ b/test-site/gatsby-config.js
@@ -8,6 +8,7 @@ module.exports = {
         apiKey: process.env.SHOPIFY_ADMIN_API_KEY,
         password: process.env.SHOPIFY_ADMIN_PASSWORD,
         storeUrl: process.env.SHOPIFY_STORE_URL,
+        shopifyConnections: ["collections"],
       },
     },
   ],

--- a/test-site/gatsby-config.js
+++ b/test-site/gatsby-config.js
@@ -8,7 +8,6 @@ module.exports = {
         apiKey: process.env.SHOPIFY_ADMIN_API_KEY,
         password: process.env.SHOPIFY_ADMIN_PASSWORD,
         storeUrl: process.env.SHOPIFY_STORE_URL,
-        shopifyConnections: ["collections"],
       },
     },
   ],


### PR DESCRIPTION
## Why?

We have some plugin options that should change the schema:

1. `downloadImages` - if I user sets this to true, image files will be linked to a local file node. That local file should not appear in the schema unless a user wants to download the images up front.
2. `shopifyConnections` - some node types shouldn't even exist unless users want them. Currently we require users to opt-in to sourcing orders and collections. Products also have a reference to collections which shouldn't exist if collections haven't been requested.

## How?

Using type builders, we can conditionally define node types and fields.