### PR TITLE
Refactored to remove recursive function and added object count and status

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -23,7 +23,8 @@
     "gatsby-core-utils": "^2.1.0",
     "gatsby-source-filesystem": "^3.1.0",
     "node-fetch": "^2.6.1",
-    "sharp": "^0.27.2"
+    "sharp": "^0.27.2",
+    "shift-left": "^0.1.5"
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",

--- a/plugin/src/client.ts
+++ b/plugin/src/client.ts
@@ -1,4 +1,5 @@
 import fetch from "node-fetch";
+import { HttpError } from "./errors";
 
 const adminUrl = (options: ShopifyPluginOptions) =>
   `https://${options.apiKey}:${options.password}@${options.storeUrl}/admin/api/2021-01/graphql.json`;
@@ -31,7 +32,7 @@ export function createClient(options: ShopifyPluginOptions) {
         return graphqlFetch(query, variables, retries + 1);
       }
 
-      throw response;
+      throw new HttpError(response);
     }
 
     const json = await response.json();

--- a/plugin/src/errors.ts
+++ b/plugin/src/errors.ts
@@ -1,6 +1,9 @@
+import { Response } from "node-fetch";
+
 export const pluginErrorCodes = {
   bulkOperationFailed: "111000",
   unknownSourcingFailure: "111001",
+  unknownApiError: "111002",
 };
 
 export class OperationError extends Error {
@@ -11,5 +14,15 @@ export class OperationError extends Error {
     super(`Operation ${id} failed with ${errorCode}`);
     Object.setPrototypeOf(this, OperationError.prototype);
     this.node = node;
+  }
+}
+
+export class HttpError extends Error {
+  public response: Response;
+
+  constructor(response: Response) {
+    super(response.statusText);
+    Object.setPrototypeOf(this, HttpError.prototype);
+    this.response = response;
   }
 }

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -262,5 +262,10 @@ export function onPreInit({ reporter }: NodePluginArgs) {
       level: "ERROR",
       category: `THIRD_PARTY`,
     },
+    [errorCodes.unknownApiError]: {
+      text: getErrorText,
+      level: "ERROR",
+      category: `THIRD_PARTY`,
+    },
   });
 }

--- a/plugin/src/make-source-from-operation.ts
+++ b/plugin/src/make-source-from-operation.ts
@@ -164,6 +164,7 @@ export function makeSourceFromOperation(
         });
       }
 
+      console.error("Unexpected error encountered: ", e);
       reporter.panic({
         id: errorCodes.unknownSourcingFailure,
         context: {

--- a/plugin/src/make-source-from-operation.ts
+++ b/plugin/src/make-source-from-operation.ts
@@ -1,15 +1,17 @@
 import fetch from "node-fetch";
 import { SourceNodesArgs } from "gatsby";
 import { createInterface } from "readline";
+import { shiftLeft } from "shift-left";
 
 import { nodeBuilder } from "./node-builder";
 import { ShopifyBulkOperation } from "./operations";
 import { OperationError, pluginErrorCodes as errorCodes } from "./errors";
 import { LAST_SHOPIFY_BULK_OPERATION } from "./constants";
 
+
 export function makeSourceFromOperation(
   finishLastOperation: () => Promise<void>,
-  completedOperation: (id: string) => Promise<{ node: BulkOperationNode }>,
+  completedOperation: (id: string, callback: (node: BulkOperationNode) => void) => Promise<{ node: BulkOperationNode }>,
   cancelOperationInProgress: () => Promise<void>,
   gatsbyApi: SourceNodesArgs,
   pluginOptions: ShopifyPluginOptions
@@ -58,12 +60,17 @@ export function makeSourceFromOperation(
         );
       }
 
-      operationTimer.setStatus(
-        `Polling bulk operation ${op.name}: ${bulkOperation.id}`
-      );
-      await cache.set(cacheKey, bulkOperation.id);
+      const updateStatus = (operationStats: BulkOperationNode) => {
+        operationTimer.setStatus(shiftLeft`
+          Polling bulk operation: ${bulkOperation.id}
+          Status: ${operationStats.status}
+          Object count: ${operationStats.objectCount}
+        `);
+      }
 
-      let resp = await completedOperation(bulkOperation.id);
+      await cache.set(cacheKey, bulkOperation.id);
+      
+      let resp = await completedOperation(bulkOperation.id, updateStatus);
       reporter.info(`Completed bulk operation ${op.name}: ${bulkOperation.id}`);
 
       if (parseInt(resp.node.objectCount, 10) === 0) {

--- a/plugin/src/operations.ts
+++ b/plugin/src/operations.ts
@@ -168,14 +168,7 @@ export function createOperations(
         id: operationId,
       });
 
-      const operationNodeFields = Object.keys(operation.node) as (keyof BulkOperationNode)[];
-      let updated: boolean = false;
-
-      operationNodeFields.forEach(field => {
-        if (nextOperation.node[field] !== operation.node[field]) {
-          updated = true;
-        };
-      });
+      const updated: boolean = JSON.stringify(operation.node) !== JSON.stringify(nextOperation.node);
 
       if (updated) nodeStatsChangedCallback(nextOperation.node);
 

--- a/plugin/src/operations.ts
+++ b/plugin/src/operations.ts
@@ -126,39 +126,61 @@ export function createOperations(
    */
   async function completedOperation(
     operationId: string,
+    nodeStatsChangedCallback: (node: BulkOperationNode) => void,
     interval = 1000
   ): Promise<{ node: BulkOperationNode }> {
-    const operation = await client.request<{
-      node: BulkOperationNode;
-    }>(OPERATION_BY_ID, {
-      id: operationId,
-    });
+    let operation = await client.request<{
+        node: BulkOperationNode;
+      }>(OPERATION_BY_ID, {
+        id: operationId,
+      });
 
-    if (options.verboseLogging) {
-      reporter.verbose(`
-        Waiting for operation to complete
+    nodeStatsChangedCallback(operation.node);
+    
+    while (true) {
+      if (options.verboseLogging) {
+        reporter.verbose(`
+          Waiting for operation to complete
 
-        ${operationId}
+          ${operationId}
 
-        Status: ${operation.node.status}
+          Status: ${operation.node.status}
 
-        Object count: ${operation.node.objectCount}
+          Object count: ${operation.node.objectCount}
 
-        Url: ${operation.node.url}
-      `);
+          Url: ${operation.node.url}
+        `);
+      }
+
+      if (failedStatuses.includes(operation.node.status)) {
+        throw new OperationError(operation.node);
+      }
+
+      if (operation.node.status === "COMPLETED") {
+        return operation;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, interval));
+
+      const nextOperation = await client.request<{
+        node: BulkOperationNode;
+      }>(OPERATION_BY_ID, {
+        id: operationId,
+      });
+
+      const operationNodeFields = Object.keys(operation.node) as (keyof BulkOperationNode)[];
+      let updated: boolean = false;
+
+      operationNodeFields.forEach(field => {
+        if (nextOperation.node[field] !== operation.node[field]) {
+          updated = true;
+        };
+      });
+
+      if (updated) nodeStatsChangedCallback(nextOperation.node);
+
+      operation = nextOperation;
     }
-
-    if (failedStatuses.includes(operation.node.status)) {
-      throw new OperationError(operation.node);
-    }
-
-    if (operation.node.status === "COMPLETED") {
-      return operation;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, interval));
-
-    return completedOperation(operationId, interval);
   }
 
   return {

--- a/plugin/test/fixtures.ts
+++ b/plugin/test/fixtures.ts
@@ -27,18 +27,26 @@ export function currentBulkOperation(status: BulkOperationStatus) {
   };
 }
 
-export const startOperation = graphql.mutation<BulkOperationRunQueryResponse>(
-  "INITIATE_BULK_OPERATION",
-  resolve({
-    bulkOperationRunQuery: {
-      bulkOperation: {
-        id: "",
-        objectCount: "0",
-        query: "",
-        status: "CREATED",
-        url: "",
+type BulkNodeOverrides = {
+  [key in keyof BulkOperationNode]?: BulkOperationNode[key];
+};
+
+export const startOperation = (overrides: BulkNodeOverrides = {}) => {
+  const { id = "12345" } = overrides;
+
+  return graphql.mutation<BulkOperationRunQueryResponse>(
+    "INITIATE_BULK_OPERATION",
+    resolve({
+      bulkOperationRunQuery: {
+        bulkOperation: {
+          id,
+          objectCount: "0",
+          query: "",
+          status: "CREATED",
+          url: "",
+        },
+        userErrors: [],
       },
-      userErrors: [],
-    },
-  })
-);
+    })
+  );
+};

--- a/plugin/test/sample-test.spec.ts
+++ b/plugin/test/sample-test.spec.ts
@@ -41,7 +41,7 @@ test("Sample test", async () => {
     args()
   );
 
-  const resp = await operations.completedOperation(`12345`);
+  const resp = await operations.completedOperation(`12345`, () => {});
 
   expect(resp.node.status).toEqual(`COMPLETED`);
   expect(resp.node.id).toEqual(`12345`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -11223,6 +11223,11 @@ shellwords@^0.1.1:
   resolved "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
+shift-left@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/shift-left/-/shift-left-0.1.5.tgz#4a61a9d0412b1b32f9abbd97f72466c9c74a6be1"
+  integrity sha512-55d8QaP1YmuL1D52fhgq8CT1tXksM/2WPZ6980RtkMbl0Cze++kuJy50GLMnXwostk/YG9hasaJmP3r+d3yUtQ==
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"


### PR DESCRIPTION
Added object count and status updates in the console for better user experience. Users can now see how far along their bulk operation is.

Also refactored the polling method to not be recursive to save space.

Testing Instructions:
  - Build 10k product store (the 500 won't show gradual updates because it's done too quick)
  - Can take a couple minutes to receive an update, the Bulk API does not register updated counts immediately (ie, it will jump from 0 -> 5000)
  - Should see something like
```
⠴ Source from bulk operation PRODUCTS —
Polling bulk operation: gid://shopify/BulkOperation/317974249666
Status: RUNNING
Object count: 0
```