### PR TITLE
Add extra logging to unhandled errors for debugging

### DIFF
--- a/plugin/src/make-source-from-operation.ts
+++ b/plugin/src/make-source-from-operation.ts
@@ -164,6 +164,7 @@ export function makeSourceFromOperation(
         });
       }
 
+      console.error("Unexpected error encountered: ", e);
       reporter.panic({
         id: errorCodes.unknownSourcingFailure,
         context: {


### PR DESCRIPTION
This is to debug #108 

It looks to me like whatever's being thrown in this scenario is not an actual `Error` and that's why the reporter isn't displaying anything helpful. A `console.error` call should show us more about what's happening.