### PR TITLE
Better error handling for http errors

### DIFF
--- a/plugin/src/client.ts
+++ b/plugin/src/client.ts
@@ -1,4 +1,5 @@
 import fetch from "node-fetch";
+import { HttpError } from "./errors";
 
 const adminUrl = (options: ShopifyPluginOptions) =>
   `https://${options.apiKey}:${options.password}@${options.storeUrl}/admin/api/2021-01/graphql.json`;
@@ -31,7 +32,7 @@ export function createClient(options: ShopifyPluginOptions) {
         return graphqlFetch(query, variables, retries + 1);
       }
 
-      throw response;
+      throw new HttpError(response);
     }
 
     const json = await response.json();

--- a/plugin/src/errors.ts
+++ b/plugin/src/errors.ts
@@ -1,6 +1,9 @@
+import { Response } from "node-fetch";
+
 export const pluginErrorCodes = {
   bulkOperationFailed: "111000",
   unknownSourcingFailure: "111001",
+  unknownApiError: "111002",
 };
 
 export class OperationError extends Error {
@@ -11,5 +14,15 @@ export class OperationError extends Error {
     super(`Operation ${id} failed with ${errorCode}`);
     Object.setPrototypeOf(this, OperationError.prototype);
     this.node = node;
+  }
+}
+
+export class HttpError extends Error {
+  public response: Response;
+
+  constructor(response: Response) {
+    super(response.statusText);
+    Object.setPrototypeOf(this, HttpError.prototype);
+    this.response = response;
   }
 }

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -262,5 +262,10 @@ export function onPreInit({ reporter }: NodePluginArgs) {
       level: "ERROR",
       category: `THIRD_PARTY`,
     },
+    [errorCodes.unknownApiError]: {
+      text: getErrorText,
+      level: "ERROR",
+      category: `THIRD_PARTY`,
+    },
   });
 }


### PR DESCRIPTION
Some better error handling around non-ok HTTP status codes will allow us to show better feedback to the user. This will hopefully be of some additional help in #108 