### PR TITLE
chore: cleanup error classes

### DIFF
--- a/plugin/src/errors.ts
+++ b/plugin/src/errors.ts
@@ -12,8 +12,10 @@ export class OperationError extends Error {
   constructor(node: BulkOperationNode) {
     const { errorCode, id } = node;
     super(`Operation ${id} failed with ${errorCode}`);
-    Object.setPrototypeOf(this, OperationError.prototype);
+
     this.node = node;
+    
+    Error.captureStackTrace(this, OperationError);
   }
 }
 
@@ -22,7 +24,9 @@ export class HttpError extends Error {
 
   constructor(response: Response) {
     super(response.statusText);
-    Object.setPrototypeOf(this, HttpError.prototype);
+
     this.response = response;
+
+    Error.captureStackTrace(this, HttpError);
   }
 }


### PR DESCRIPTION
We don't need `setPrototypeOf`. Classes take care of it themselves. Typescript says that you should https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-2.html but it's only necessary when you use Typescript to compile to es5 as it doesn't properly transpile to correct es5 syntax. When using babel like gatsby does, it gets transpiled correctly.

For the shopify plugin it doesn't matter cause everything is handled in node and it's not being transpiled to es5.

I've also added  captureStackTrace which removes an extra line from the stacktrace.