### PR TITLE
Dump result URLs for debugging

### DIFF
--- a/plugin/src/make-source-from-operation.ts
+++ b/plugin/src/make-source-from-operation.ts
@@ -12,10 +12,12 @@ import {
 } from "./errors";
 import { LAST_SHOPIFY_BULK_OPERATION } from "./constants";
 
-
 export function makeSourceFromOperation(
   finishLastOperation: () => Promise<void>,
-  completedOperation: (id: string, callback: (node: BulkOperationNode) => void) => Promise<{ node: BulkOperationNode }>,
+  completedOperation: (
+    id: string,
+    callback: (node: BulkOperationNode) => void
+  ) => Promise<{ node: BulkOperationNode }>,
   cancelOperationInProgress: () => Promise<void>,
   gatsbyApi: SourceNodesArgs,
   pluginOptions: ShopifyPluginOptions
@@ -70,10 +72,10 @@ export function makeSourceFromOperation(
           Status: ${operationStats.status}
           Object count: ${operationStats.objectCount}
         `);
-      }
+      };
 
       await cache.set(cacheKey, bulkOperation.id);
-      
+
       let resp = await completedOperation(bulkOperation.id, updateStatus);
       reporter.info(`Completed bulk operation ${op.name}: ${bulkOperation.id}`);
 
@@ -86,6 +88,10 @@ export function makeSourceFromOperation(
       operationTimer.setStatus(
         `Fetching ${resp.node.objectCount} results for ${op.name}: ${bulkOperation.id}`
       );
+
+      if (pluginOptions.debugMode) {
+        console.info(`Fetching results for ${op.name} at ${resp.node.url}`);
+      }
 
       const results = await fetch(resp.node.url);
 

--- a/plugin/src/processors.ts
+++ b/plugin/src/processors.ts
@@ -37,12 +37,6 @@ export function collectionsProcessor(
         const [siblingId, siblingRemoteType] =
           objects[j].id.match(idPattern) || [];
 
-        if (pluginOptions.debugMode) {
-          console.info(
-            `Processing collection ${result.__parentId} child node ${objects[j].id}`
-          );
-        }
-
         if (siblingRemoteType === `Product`) {
           productIds.push(createNodeId(siblingId, gatsbyApi, pluginOptions));
         }
@@ -57,22 +51,10 @@ export function collectionsProcessor(
 
       const nextSlice = objects.slice(0, j);
 
-      if (pluginOptions.debugMode) {
-        console.info(
-          `Ready to create collection '${collection.title}' with child product IDs:`,
-          collection.productIds
-        );
-      }
-
       return promises.concat(
         collectionsProcessor(nextSlice, builder, gatsbyApi, pluginOptions)
       );
     } else {
-      if (pluginOptions.debugMode) {
-        console.info(
-          `Ready to create collection '${result.title}' with no child products`
-        );
-      }
       promises.push(builder.buildNode(result));
     }
   }


### PR DESCRIPTION
It really looks like results are being returned in the wrong order in #94. Shopify promises a certain order for these JSONL results, but the output we've seen would seem to indicate that this is not being honored. So we just need to have a look at the file to be sure.

If it's not in the right order as suspected, there are a couple things we should possibly do:

1. File a bug with Shopify
2. Rewrite the processor so order doesn't matter (this one's more of a maybe)