### PR TITLE
Fix bad assumptions in collection processing

### DIFF
--- a/plugin/src/make-source-from-operation.ts
+++ b/plugin/src/make-source-from-operation.ts
@@ -3,7 +3,7 @@ import { SourceNodesArgs } from "gatsby";
 import { createInterface } from "readline";
 import { shiftLeft } from "shift-left";
 
-import { nodeBuilder, pattern as idPattern } from "./node-builder";
+import { nodeBuilder } from "./node-builder";
 import { ShopifyBulkOperation } from "./operations";
 import {
   OperationError,
@@ -89,10 +89,6 @@ export function makeSourceFromOperation(
         `Fetching ${resp.node.objectCount} results for ${op.name}: ${bulkOperation.id}`
       );
 
-      if (pluginOptions.debugMode) {
-        console.info(`Fetching results for ${op.name} at ${resp.node.url}`);
-      }
-
       const results = await fetch(resp.node.url);
 
       operationTimer.setStatus(
@@ -109,26 +105,6 @@ export function makeSourceFromOperation(
 
       for await (const line of rl) {
         objects.push(JSON.parse(line));
-      }
-
-      if (pluginOptions.debugMode) {
-        const nodeTypeCounts = objects.reduce((grouping, object) => {
-          const [, remoteType] = object.id.match(idPattern);
-          if (!grouping[remoteType]) {
-            grouping[remoteType] = 0;
-          }
-
-          grouping[remoteType]++;
-          return grouping;
-        }, {});
-
-        const output = Object.entries(nodeTypeCounts)
-          .map(([remoteType, count]) => {
-            return `${remoteType}: ${count} results`;
-          })
-          .join("\n");
-
-        reporter.info(output);
       }
 
       await Promise.all(

--- a/plugin/src/processors.ts
+++ b/plugin/src/processors.ts
@@ -36,9 +36,8 @@ export function collectionsProcessor(
     }
 
     if (remoteType == `Collection`) {
-      const collection = objects[i];
-      collection.productIds = collectionProductIndex[result.id] || [];
-      promises.push(builder.buildNode(collection));
+      result.productIds = collectionProductIndex[result.id] || [];
+      promises.push(builder.buildNode(result));
     }
   }
 

--- a/plugin/src/processors.ts
+++ b/plugin/src/processors.ts
@@ -8,54 +8,25 @@ export function collectionsProcessor(
   pluginOptions: ShopifyPluginOptions
 ): Promise<NodeInput>[] {
   const promises = [];
+  const collectionProductIndex: { [collectionId: string]: string[] } = {};
 
-  /**
-   * Read results in reverse so we can collect child node IDs.
-   * See Shopify Bulk Operation guide for more info.
-   *
-   * https://shopify.dev/tutorials/perform-bulk-operations-with-admin-api#download-result-data
-   */
   for (let i = objects.length - 1; i >= 0; i--) {
     const result = objects[i];
-    const [, remoteType] = result.id.match(idPattern) || [];
-    if (remoteType !== `Collection`) {
-      /**
-       * Collect product node IDs until we get to the parent collection.
-       * This is necessary for many-to-many relationships, like the
-       * products connection, which is currently the only connection
-       * we are requesting.
-       *
-       * One-to-many relationships wouldn't need this,
-       * e.g. if the remote type is a metafield we can just create a
-       * metafield node with a collectionId.
-       *
-       */
-      const productIds = [];
-      let j = i;
-
-      while (objects[j].id !== result.__parentId) {
-        const [siblingId, siblingRemoteType] =
-          objects[j].id.match(idPattern) || [];
-
-        if (siblingRemoteType === `Product`) {
-          productIds.push(createNodeId(siblingId, gatsbyApi, pluginOptions));
-        }
-
-        j--;
+    const [id, remoteType] = result.id.match(idPattern) || [];
+    if (remoteType === `Product`) {
+      if (!collectionProductIndex[result.__parentId]) {
+        collectionProductIndex[result.__parentId] = [];
       }
 
-      const collection = objects[j];
-
-      collection.productIds = productIds;
-      promises.push(builder.buildNode(collection));
-
-      const nextSlice = objects.slice(0, j);
-
-      return promises.concat(
-        collectionsProcessor(nextSlice, builder, gatsbyApi, pluginOptions)
+      collectionProductIndex[result.__parentId].push(
+        createNodeId(id, gatsbyApi, pluginOptions)
       );
-    } else {
-      promises.push(builder.buildNode(result));
+    }
+
+    if (remoteType == `Collection`) {
+      const collection = objects[i];
+      collection.productIds = collectionProductIndex[result.id] || [];
+      promises.push(builder.buildNode(collection));
     }
   }
 

--- a/plugin/src/processors.ts
+++ b/plugin/src/processors.ts
@@ -10,10 +10,22 @@ export function collectionsProcessor(
   const promises = [];
   const collectionProductIndex: { [collectionId: string]: string[] } = {};
 
+  /**
+   * Read results in reverse so we can collect child node IDs.
+   * See Shopify Bulk Operation guide for more info.
+   *
+   * https://shopify.dev/tutorials/perform-bulk-operations-with-admin-api#download-result-data
+   */
   for (let i = objects.length - 1; i >= 0; i--) {
     const result = objects[i];
     const [id, remoteType] = result.id.match(idPattern) || [];
     if (remoteType === `Product`) {
+      /**
+       * We source products in a separate operation. Here we are
+       * just collecting product IDs so we can tell Gatsby about
+       * the many-to-many relationship between collections and
+       * products.
+       */
       if (!collectionProductIndex[result.__parentId]) {
         collectionProductIndex[result.__parentId] = [];
       }

--- a/test-site/gatsby-config.js
+++ b/test-site/gatsby-config.js
@@ -9,7 +9,6 @@ module.exports = {
         password: process.env.SHOPIFY_ADMIN_PASSWORD,
         storeUrl: process.env.SHOPIFY_STORE_URL,
         shopifyConnections: ["collections"],
-        debugMode: true,
       },
     },
   ],


### PR DESCRIPTION
This should finally fix #94 

I was operating on some incorrect assumptions with the collections processor. Although child nodes are guaranteed to show up after their parent node, they are not in fact guaranteed to be _grouped with_ the parent, [as explained in the docs](https://shopify.dev/tutorials/perform-bulk-operations-with-admin-api#download-result-data)

> however, child nodes might not appear directly after their parent. For example, in the following results, the product variant with title 52 is a child of the first product in the file.