### PR TITLE
Schema improvements

### DIFF
--- a/plugin/src/create-schema-customization.ts
+++ b/plugin/src/create-schema-customization.ts
@@ -105,6 +105,8 @@ export function createSchemaCustomization(
     }
   );
 
+  productImageDef.config.interfaces = ["Node"];
+
   if (includeCollections) {
     addFields(productDef, {
       collections: {

--- a/plugin/src/create-schema-customization.ts
+++ b/plugin/src/create-schema-customization.ts
@@ -1,4 +1,55 @@
-import { CreateSchemaCustomizationArgs } from "gatsby";
+import {
+  CreateSchemaCustomizationArgs,
+  NodePluginSchema,
+  GatsbyGraphQLObjectType,
+} from "gatsby";
+
+function addFields(
+  def: GatsbyGraphQLObjectType,
+  fields: GatsbyGraphQLObjectType["config"]["fields"]
+) {
+  def.config.fields = {
+    ...(def.config.fields || {}),
+    ...fields,
+  };
+}
+
+function defineImageNode(
+  name: string,
+  schema: NodePluginSchema,
+  pluginOptions: ShopifyPluginOptions,
+  fields: GatsbyGraphQLObjectType["config"]["fields"] = {}
+) {
+  const imageDef = schema.buildObjectType({
+    name,
+    extensions: {
+      dontInfer: {},
+    },
+  });
+
+  if (pluginOptions.downloadImages) {
+    imageDef.config.fields = {
+      localFile: {
+        type: "File",
+        extensions: {
+          link: {},
+        },
+      },
+    };
+  }
+
+  addFields(imageDef, {
+    ...fields,
+    altText: "String",
+    height: "Int",
+    id: "String",
+    originalSrc: "String!",
+    transformedSrc: "String!",
+    width: "Int",
+  });
+
+  return imageDef;
+}
 
 export function createSchemaCustomization(
   { actions, schema }: CreateSchemaCustomizationArgs,
@@ -37,9 +88,11 @@ export function createSchemaCustomization(
     interfaces: ["Node"],
   });
 
-  const productImageDef = schema.buildObjectType({
-    name: name("ShopifyProductImage"),
-    fields: {
+  const productImageDef = defineImageNode(
+    name("ShopifyProductImage"),
+    schema,
+    pluginOptions,
+    {
       product: {
         type: name("ShopifyProduct!"),
         extensions: {
@@ -49,29 +102,21 @@ export function createSchemaCustomization(
           },
         },
       },
-    },
-    interfaces: ["Node"],
-  });
+    }
+  );
 
-  if (pluginOptions.downloadImages && productImageDef.config.fields) {
-    productImageDef.config.fields.localFile = {
-      type: "File",
-      extensions: {
-        link: {},
-      },
-    };
-  }
-
-  if (includeCollections && productDef.config.fields) {
-    productDef.config.fields.collections = {
-      type: `[${name("ShopifyCollection")}]`,
-      extensions: {
-        link: {
-          from: "id",
-          by: "productIds",
+  if (includeCollections) {
+    addFields(productDef, {
+      collections: {
+        type: `[${name("ShopifyCollection")}]`,
+        extensions: {
+          link: {
+            from: "id",
+            by: "productIds",
+          },
         },
       },
-    };
+    });
   }
 
   const typeDefs = [
@@ -188,50 +233,18 @@ export function createSchemaCustomization(
     );
   }
 
-  if (pluginOptions.downloadImages) {
-    typeDefs.push(
-      schema.buildObjectType({
-        name: name("ShopifyProductFeaturedImage"),
-        fields: {
-          localFile: {
-            type: "File",
-            extensions: {
-              link: {},
-            },
-          },
-        },
-        interfaces: ["Node"],
-      }),
-      schema.buildObjectType({
-        name: name("ShopifyProductFeaturedMediaPreviewImage"),
-        fields: {
-          localFile: {
-            type: "File",
-            extensions: {
-              link: {},
-            },
-          },
-        },
-        interfaces: ["Node"],
-      })
-    );
+  typeDefs.push(
+    ...[
+      "ShopifyProductFeaturedImage",
+      "ShopifyProductFeaturedMediaPreviewImage",
+      "ShopifyProductVariantImage",
+    ].map((typeName) => defineImageNode(name(typeName), schema, pluginOptions))
+  );
 
-    if (includeCollections) {
-      typeDefs.push(
-        schema.buildObjectType({
-          name: name("ShopifyCollectionImage"),
-          fields: {
-            localFile: {
-              type: "File",
-              extensions: {
-                link: {},
-              },
-            },
-          },
-          interfaces: ["Node"],
-        })
-      );
-    }
+  if (includeCollections) {
+    typeDefs.push(
+      defineImageNode(name("ShopifyCollectionImage"), schema, pluginOptions)
+    );
   }
 
   actions.createTypes(typeDefs);

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -204,7 +204,11 @@ export async function sourceNodes(
 
 export function createResolvers(
   { createResolvers, cache }: CreateResolversArgs,
-  { downloadImages, typePrefix = "" }: ShopifyPluginOptions
+  {
+    downloadImages,
+    typePrefix = "",
+    shopifyConnections = [],
+  }: ShopifyPluginOptions
 ) {
   if (!downloadImages) {
     const args = {
@@ -218,9 +222,12 @@ export function createResolvers(
       `ShopifyProductImage`,
       `ShopifyProductVariantImage`,
       `ShopifyProductFeaturedImage`,
-      `ShopifyCollectionImage`,
       `ShopifyProductFeaturedMediaPreviewImage`,
     ];
+
+    if (shopifyConnections.includes("collections")) {
+      imageNodeTypes.push("ShopifyCollectionImage");
+    }
 
     const resolvers = imageNodeTypes.reduce(
       (r, nodeType) => ({


### PR DESCRIPTION
A couple improvements here mainly to how we deal with child images.

1. They are unconditionally defined in the schema, but not as nodes
2. They are now defined consistently

This gets rid of some build warnings and reduces noise in GraphiQL 🎉 

## Testing

Test with both `downloadImages: true` and without. Also test with `shopifyConnections: ["collections"]` and without. Ensure the following:

1. There are no schema warnings (test that with an inc build too)
2. You're able to resolve the image types shown in the code (e.g. product images, product featured images & media, product variant images, collection images)
3. For child image types (e.g. product featured image, product featured media, product variant image, collection image), they should not be queryable as nodes in GraphiQL. They should only be accessible through their parent node.