### PR TITLE
Put keys in the header

### DIFF
--- a/plugin/src/client.ts
+++ b/plugin/src/client.ts
@@ -2,7 +2,7 @@ import fetch from "node-fetch";
 import { HttpError } from "./errors";
 
 const adminUrl = (options: ShopifyPluginOptions) =>
-  `https://${options.apiKey}:${options.password}@${options.storeUrl}/admin/api/2021-01/graphql.json`;
+  `https://@${options.storeUrl}/admin/api/2021-01/graphql.json`;
 
 const MAX_BACKOFF_MILLISECONDS = 60000;
 
@@ -18,6 +18,7 @@ export function createClient(options: ShopifyPluginOptions) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        "X-Shopify-Access-Token": options.password,
       },
       body: JSON.stringify({
         query,

--- a/plugin/src/events.ts
+++ b/plugin/src/events.ts
@@ -11,7 +11,7 @@ export function eventsApi(options: ShopifyPluginOptions) {
   return {
     async fetchDestroyEventsSince(date: Date): Promise<Event[]> {
       let resp = await shopifyFetch(
-        `/events.json?limit=1&verb=destroy&created_at_min=${date.toISOString()}`
+        `/events.json?limit=250&verb=destroy&created_at_min=${date.toISOString()}`
       );
 
       const { events } = await resp.json();

--- a/plugin/src/events.ts
+++ b/plugin/src/events.ts
@@ -25,10 +25,7 @@ export function eventsApi(options: ShopifyPluginOptions) {
         const pageLinks: { url: string; rel: string }[] = paginationInfo
           .split(",")
           .map((pageData: string) => {
-            const [, url, rel] = pageData.match(/<(.*)>; rel="(.*)"/) || [
-              "",
-              "",
-            ];
+            const [, url, rel] = pageData.match(/<(.*)>; rel="(.*)"/) || [];
             return {
               url,
               rel,

--- a/plugin/src/events.ts
+++ b/plugin/src/events.ts
@@ -11,7 +11,7 @@ export function eventsApi(options: ShopifyPluginOptions) {
   return {
     async fetchDestroyEventsSince(date: Date): Promise<Event[]> {
       let resp = await shopifyFetch(
-        `/events.json?limit=250&verb=destroy&created_at_min=${date.toISOString()}`
+        `/events.json?limit=1&verb=destroy&created_at_min=${date.toISOString()}`
       );
 
       const { events } = await resp.json();
@@ -25,7 +25,10 @@ export function eventsApi(options: ShopifyPluginOptions) {
         const pageLinks: { url: string; rel: string }[] = paginationInfo
           .split(",")
           .map((pageData: string) => {
-            const [url, rel] = pageData.match(/<(.*)>; rel="(.*)"/) || ["", ""];
+            const [, url, rel] = pageData.match(/<(.*)>; rel="(.*)"/) || [
+              "",
+              "",
+            ];
             return {
               url,
               rel,


### PR DESCRIPTION
## Why?

There's a security problem. This code has been authenticating requests by attaching tokens to the URL, and these URLs can show up in build logs if an error occurs when making the API call. 

## What to do?

Stash the secrets in headers in stead of the URL.

### Why weren't you doing that already?

I tried and couldn't make it work. Turns out I was using the wrong key 🤦🏼‍♂️ 