### PR TITLE
Panic if a production conflict is detected

### DIFF
--- a/plugin/src/errors.ts
+++ b/plugin/src/errors.ts
@@ -4,6 +4,8 @@ export const pluginErrorCodes = {
   bulkOperationFailed: "111000",
   unknownSourcingFailure: "111001",
   unknownApiError: "111002",
+
+  apiConflict: "111003",
 };
 
 export class OperationError extends Error {

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -258,6 +258,11 @@ export function onPreInit({ reporter }: NodePluginArgs) {
       level: `ERROR`,
       category: `USER`,
     },
+    [errorCodes.apiConflict]: {
+      text: getErrorText,
+      level: `ERROR`,
+      category: `USER`,
+    },
     /**
      * If we don't know what it is, we haven't done our due
      * diligence to handle it explicitly. That means it's our

--- a/plugin/src/gatsby-node.ts
+++ b/plugin/src/gatsby-node.ts
@@ -11,6 +11,7 @@ import {
   getGatsbyImageResolver,
   IGatsbyGraphQLResolverArgumentConfig,
 } from "gatsby-plugin-image/graphql-utils";
+import { shiftLeft } from "shift-left";
 import { pluginErrorCodes as errorCodes } from "./errors";
 import { LAST_SHOPIFY_BULK_OPERATION } from "./constants";
 import { makeSourceFromOperation } from "./make-source-from-operation";
@@ -259,7 +260,15 @@ export function onPreInit({ reporter }: NodePluginArgs) {
       category: `USER`,
     },
     [errorCodes.apiConflict]: {
-      text: getErrorText,
+      text: () => shiftLeft`
+        Your operation was canceled. You might have another production site for this Shopify store.
+
+        Shopify only allows one bulk operation at a time for a given shop, so we recommend that you
+        avoid having two production sites that point to the same Shopify store.
+
+        If the duplication is intentional, please wait for the other operation to finish before trying
+        again. Otherwise, consider deleting the other site or pointing it to a test store instead.
+      `,
       level: `ERROR`,
       category: `USER`,
     },

--- a/plugin/src/make-source-from-operation.ts
+++ b/plugin/src/make-source-from-operation.ts
@@ -127,15 +127,15 @@ export function makeSourceFromOperation(
               error: e,
               context: {},
             });
+          } else {
+            // A prod build canceled me, wait and try again
+            operationTimer.setStatus(
+              "This operation has been canceled by a higher priority build. It will retry shortly."
+            );
+            operationTimer.end();
+            await new Promise((resolve) => setTimeout(resolve, 5000));
+            await sourceFromOperation(op);
           }
-
-          // A prod build canceled me, wait and try again
-          operationTimer.setStatus(
-            "This operation has been canceled by a higher priority build. It will retry shortly."
-          );
-          operationTimer.end();
-          await new Promise((resolve) => setTimeout(resolve, 5000));
-          await sourceFromOperation(op);
         }
 
         if (e.node.errorCode === `ACCESS_DENIED`) {

--- a/plugin/src/make-source-from-operation.ts
+++ b/plugin/src/make-source-from-operation.ts
@@ -10,7 +10,6 @@ import {
   pluginErrorCodes as errorCodes,
 } from "./errors";
 import { LAST_SHOPIFY_BULK_OPERATION } from "./constants";
-import { shiftLeft } from "shift-left";
 
 export function makeSourceFromOperation(
   finishLastOperation: () => Promise<void>,
@@ -126,17 +125,7 @@ export function makeSourceFromOperation(
             reporter.panic({
               id: errorCodes.apiConflict,
               error: e,
-              context: {
-                sourceMessage: shiftLeft`
-                  Your operation was canceled. You might have another production site for this Shopify store.
-
-                  Shopify only allows one bulk operation at a time for a given shop, so we recommend that you
-                  avoid having two production sites that point to the same Shopify store.
-
-                  If the duplication is intentional, please wait for the other operation to finish before trying
-                  again. Otherwise, consider deleting the other site or pointing it to a test store instead.
-                `,
-              },
+              context: {},
             });
           }
 


### PR DESCRIPTION
If there are two production sites using the same store, and they try to build at the same time, they will keep cancelling each other. Let's panic if we detect this and give them some hopefully useful info.