### PR TITLE
add extra logging and context to error message

### DIFF
--- a/plugin/src/make-source-from-operation.ts
+++ b/plugin/src/make-source-from-operation.ts
@@ -1,6 +1,7 @@
 import fetch from "node-fetch";
 import { SourceNodesArgs } from "gatsby";
 import { createInterface } from "readline";
+import { shiftLeft } from "shift-left";
 
 import { nodeBuilder } from "./node-builder";
 import { ShopifyBulkOperation } from "./operations";
@@ -144,7 +145,10 @@ export function makeSourceFromOperation(
         reporter.panic({
           id: errorCodes.unknownSourcingFailure,
           context: {
-            sourceMessage: `Could not source from bulk operation: ${e.node.errorCode}`,
+            sourceMessage: shiftLeft`
+              Operation ${op.name} failed after ${e.node.objectCount} objects
+              - With status: ${e.node.status} - error code: ${e.node.errorCode}
+            `,
           },
           error: e,
         });


### PR DESCRIPTION
Relating to this customer issue https://github.com/gatsbyjs/gatsby-source-shopify/issues/140

We want to be able to get the customer to recreate this problem to get extra context as to the error that is occurring and hopefully it gives us more of a hint as to what's going wrong.