### PR TITLE
Fix variant not updating issue

### DIFF
--- a/plugin/src/operations.ts
+++ b/plugin/src/operations.ts
@@ -4,7 +4,7 @@ import { createClient } from "./client";
 import { ProductsQuery } from "./query-builders/products-query";
 import { CollectionsQuery } from "./query-builders/collections-query";
 import { OrdersQuery } from "./query-builders/orders-query";
-import { collectionsProcessor } from "./processors";
+import { collectionsProcessor, incrementalProductsProcessor } from "./processors";
 import { OperationError } from "./errors";
 
 import {
@@ -181,7 +181,8 @@ export function createOperations(
     incrementalProducts(date: Date) {
       return createOperation(
         new ProductsQuery(options).query(date),
-        "INCREMENTAL_PRODUCTS"
+        "INCREMENTAL_PRODUCTS",
+        incrementalProductsProcessor,
       );
     },
 
@@ -202,7 +203,8 @@ export function createOperations(
 
     createProductsOperation: createOperation(
       new ProductsQuery(options).query(),
-      "PRODUCTS"
+      "PRODUCTS",
+      incrementalProductsProcessor
     ),
 
     createOrdersOperation: createOperation(

--- a/plugin/src/operations.ts
+++ b/plugin/src/operations.ts
@@ -204,7 +204,6 @@ export function createOperations(
     createProductsOperation: createOperation(
       new ProductsQuery(options).query(),
       "PRODUCTS",
-      incrementalProductsProcessor
     ),
 
     createOrdersOperation: createOperation(

--- a/plugin/src/operations.ts
+++ b/plugin/src/operations.ts
@@ -4,7 +4,10 @@ import { createClient } from "./client";
 import { ProductsQuery } from "./query-builders/products-query";
 import { CollectionsQuery } from "./query-builders/collections-query";
 import { OrdersQuery } from "./query-builders/orders-query";
-import { collectionsProcessor, incrementalProductsProcessor } from "./processors";
+import {
+  collectionsProcessor,
+  incrementalProductsProcessor,
+} from "./processors";
 import { OperationError } from "./errors";
 
 import {
@@ -182,7 +185,7 @@ export function createOperations(
       return createOperation(
         new ProductsQuery(options).query(date),
         "INCREMENTAL_PRODUCTS",
-        incrementalProductsProcessor,
+        incrementalProductsProcessor
       );
     },
 
@@ -203,7 +206,7 @@ export function createOperations(
 
     createProductsOperation: createOperation(
       new ProductsQuery(options).query(),
-      "PRODUCTS",
+      "PRODUCTS"
     ),
 
     createOrdersOperation: createOperation(

--- a/plugin/src/processors/collections.ts
+++ b/plugin/src/processors/collections.ts
@@ -1,5 +1,5 @@
 import { NodeInput, SourceNodesArgs } from "gatsby";
-import { pattern as idPattern, createNodeId } from "./node-builder";
+import { pattern as idPattern, createNodeId } from "../node-builder";
 
 export function collectionsProcessor(
   objects: BulkResults,

--- a/plugin/src/processors/incremental-products.ts
+++ b/plugin/src/processors/incremental-products.ts
@@ -18,7 +18,7 @@ export function incrementalProductsProcessor(
   })
 
   const variants = gatsbyApi.getNodesByType(`${pluginOptions.typePrefix || ``}ShopifyProductVariant`).filter((node) => nodeIds.includes(node.productId as string))
-  
+
   variants.forEach(variant => {
     gatsbyApi.actions.deleteNode(variant)
   })

--- a/plugin/src/processors/incremental-products.ts
+++ b/plugin/src/processors/incremental-products.ts
@@ -1,0 +1,27 @@
+import { NodeInput, SourceNodesArgs } from "gatsby";
+import { pattern as idPattern, createNodeId } from "../node-builder";
+
+export function incrementalProductsProcessor(
+  objects: BulkResults,
+  builder: NodeBuilder,
+  gatsbyApi: SourceNodesArgs,
+  pluginOptions: ShopifyPluginOptions
+): Promise<NodeInput>[] {
+  const products = objects.filter((obj) => {
+    const [, remoteType] = obj.id.match(idPattern) || [];
+
+    return remoteType === 'Product';
+  })
+
+  const nodeIds = products.map(product => {
+    return createNodeId(product.id, gatsbyApi, pluginOptions)
+  })
+
+  const variants = gatsbyApi.getNodesByType(`${pluginOptions.typePrefix || ``}ShopifyProductVariant`).filter((node) => nodeIds.includes(node.productId as string))
+  
+  variants.forEach(variant => {
+    gatsbyApi.actions.deleteNode(variant)
+  })
+
+  return objects.map(builder.buildNode);
+}

--- a/plugin/src/processors/index.ts
+++ b/plugin/src/processors/index.ts
@@ -1,0 +1,2 @@
+export * from './collections'
+export * from './incremental-products'

--- a/plugin/test/make-source-from-operation.spec.ts
+++ b/plugin/test/make-source-from-operation.spec.ts
@@ -693,8 +693,8 @@ describe("When an operation fails with bad credentials", () => {
 
 describe("The incremental products processor", () => {
   const firstProductId = "gid://shopify/Product/22345";
-  const firstVariantId = "gid://shopify/ProductVariant/11111"
-  const secondVariantId = "gid://shopify/ProductVariant/22222"
+  const firstVariantId = "gid://shopify/ProductVariant/11111";
+  const secondVariantId = "gid://shopify/ProductVariant/22222";
 
   const bulkResults = [
     {
@@ -702,7 +702,7 @@ describe("The incremental products processor", () => {
     },
     {
       id: firstVariantId,
-      __parentId: firstProductId
+      __parentId: firstProductId,
     },
   ];
 
@@ -763,13 +763,13 @@ describe("The incremental products processor", () => {
           return [
             {
               id: firstVariantId,
-              productId: firstProductId
+              productId: firstProductId,
             },
             {
               id: secondVariantId,
-              productId: firstProductId
-            }
-          ]
+              productId: firstProductId,
+            },
+          ];
         }),
       };
     });
@@ -797,18 +797,17 @@ describe("The incremental products processor", () => {
 
     expect(deleteNode).toHaveBeenCalledTimes(2);
     expect(deleteNode).toHaveBeenCalledWith(
-      expect.objectContaining({ 
+      expect.objectContaining({
         id: firstVariantId,
-        productId: firstProductId
+        productId: firstProductId,
       })
     );
 
     expect(deleteNode).toHaveBeenCalledWith(
-      expect.objectContaining({ 
+      expect.objectContaining({
         id: secondVariantId,
-        productId: firstProductId
+        productId: firstProductId,
       })
     );
-
   });
 });

--- a/plugin/test/make-source-from-operation.spec.ts
+++ b/plugin/test/make-source-from-operation.spec.ts
@@ -690,3 +690,125 @@ describe("When an operation fails with bad credentials", () => {
     );
   });
 });
+
+describe("The incremental products processor", () => {
+  const firstProductId = "gid://shopify/Product/22345";
+  const firstVariantId = "gid://shopify/ProductVariant/11111"
+  const secondVariantId = "gid://shopify/ProductVariant/22222"
+
+  const bulkResults = [
+    {
+      id: firstProductId,
+    },
+    {
+      id: firstVariantId,
+      __parentId: firstProductId
+    },
+  ];
+
+  beforeEach(() => {
+    server.use(
+      graphql.query<CurrentBulkOperationResponse>(
+        "OPERATION_STATUS",
+        resolveOnce(currentBulkOperation("COMPLETED"))
+      ),
+      startOperation(),
+      graphql.query<{ node: BulkOperationNode }>(
+        "OPERATION_BY_ID",
+        resolve({
+          node: {
+            status: `COMPLETED`,
+            id: "12345",
+            objectCount: "2",
+            query: "",
+            url: "http://results.url",
+          },
+        })
+      ),
+      rest.get("http://results.url", (_req, res, ctx) => {
+        return res(
+          ctx.text(bulkResults.map((r) => JSON.stringify(r)).join("\n"))
+        );
+      })
+    );
+  });
+
+  it("deletes variants belonging to the products", async () => {
+    const createNode = jest.fn();
+    const deleteNode = jest.fn();
+    const createNodeId = jest.fn().mockImplementation((id) => id);
+
+    const gatsbyApiMock = jest.fn().mockImplementation(() => {
+      return {
+        cache: {
+          set: jest.fn(),
+        },
+        actions: {
+          createNode,
+          deleteNode,
+        },
+        createContentDigest: jest.fn(),
+        createNodeId,
+        reporter: {
+          info: jest.fn(),
+          error: jest.fn(),
+          panic: jest.fn(),
+          activityTimer: () => ({
+            start: jest.fn(),
+            end: jest.fn(),
+            setStatus: jest.fn(),
+          }),
+        },
+        getNodesByType: jest.fn().mockImplementation(() => {
+          return [
+            {
+              id: firstVariantId,
+              productId: firstProductId
+            },
+            {
+              id: secondVariantId,
+              productId: firstProductId
+            }
+          ]
+        }),
+      };
+    });
+
+    const gatsbyApi = gatsbyApiMock as jest.Mock<SourceNodesArgs>;
+    const options = {
+      apiKey: ``,
+      password: ``,
+      storeUrl: "my-shop.shopify.com",
+      downloadImages: true,
+    };
+    const operations = createOperations(options, gatsbyApi());
+
+    const sourceFromOperation = makeSourceFromOperation(
+      operations.finishLastOperation,
+      operations.completedOperation,
+      operations.cancelOperationInProgress,
+      gatsbyApi(),
+      options
+    );
+
+    await sourceFromOperation(operations.incrementalProducts(new Date()));
+
+    expect(createNode).toHaveBeenCalledTimes(2);
+
+    expect(deleteNode).toHaveBeenCalledTimes(2);
+    expect(deleteNode).toHaveBeenCalledWith(
+      expect.objectContaining({ 
+        id: firstVariantId,
+        productId: firstProductId
+      })
+    );
+
+    expect(deleteNode).toHaveBeenCalledWith(
+      expect.objectContaining({ 
+        id: secondVariantId,
+        productId: firstProductId
+      })
+    );
+
+  });
+});


### PR DESCRIPTION
Fix for issue https://github.com/gatsbyjs/gatsby-source-shopify/issues/149

Updating a variant does not kick off an event as we had previously thought. We were observing events to update variants, so variants were not getting updated as they should have been.

Variants changes are associated with `Product` changes. Therefore to ensure that the variants are up to date with the product information we get in `sourceChangedNodes`, we delete all variants associated with the products being updated and then rebuild the variants according to that information. This will guarantee that Variants get deleted and created as they should.

We wrote a custom processor for `incrementalProducts` to take into account these changes. Moving forward, as the number of custom processors is more than one, we also created a folder for all the custom processors to be organized in one location