### PR TITLE
add sort key to product images

### DIFF
--- a/plugin/src/query-builders/products-query.ts
+++ b/plugin/src/query-builders/products-query.ts
@@ -13,6 +13,7 @@ export class ProductsQuery extends BulkQuery {
     }
 
     const ProductVariantSortKey = `POSITION`;
+    const ProductImageSortKey = `POSITION`;
 
     const queryString = filters.map((f) => `(${f})`).join(" AND ");
 
@@ -111,7 +112,7 @@ export class ProductsQuery extends BulkQuery {
               tracksInventory
               updatedAt
               vendor
-              images {
+              images(sortKey: ${ProductImageSortKey}) {
                 edges {
                   node {
                     id


### PR DESCRIPTION
Relating to issue https://github.com/gatsbyjs/gatsby-source-shopify/issues/131

- Added a `sortKey` to explicitly sort by `POSITION` for `ProductImages`